### PR TITLE
Do full reconcile hourly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ export GO111MODULE=on
 VERSION_PACKAGE = github.com/replicatedhq/ekco/pkg/version
 VERSION ?= `git describe --tags --dirty`
 DATE = `date -u +"%Y-%m-%dT%H:%M:%SZ"`
+CURRENT_USER=$(shell id -u -n)
 
 ifndef GIT_SHA
 GIT_TREE = $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
@@ -70,3 +71,11 @@ docker-image:
 		--build-arg git_sha="$(GIT_SHA)" \
 		--build-arg version="$(VERSION)" \
 		.
+build-ttl.sh:
+	docker build \
+		-t ttl.sh/${CURRENT_USER}/ekco:12h \
+		-f deploy/Dockerfile \
+		--build-arg git_sha=dev \
+		--build-arg version=dev \
+		.
+	docker push ttl.sh/${CURRENT_USER}/ekco:12h

--- a/pkg/cluster/rook_ceph.go
+++ b/pkg/cluster/rook_ceph.go
@@ -109,8 +109,8 @@ func (c *Controller) deleteK8sDeploymentOSD(name string) (string, error) {
 	return osdID, nil
 }
 
-// SetPoolReplicationLevel ignores NotFound errors.
-func (c *Controller) SetPoolReplication(name string, level int) error {
+// SetBlockPoolReplicationLevel ignores NotFound errors.
+func (c *Controller) SetBlockPoolReplication(name string, level int, doFullReconcile bool) error {
 	if name == "" {
 		return nil
 	}
@@ -123,7 +123,12 @@ func (c *Controller) SetPoolReplication(name string, level int) error {
 		return errors.Wrapf(err, "get CephBlockPool %s", name)
 	}
 	current := int(pool.Spec.Replicated.Size)
-	if current != level {
+	if current != level || doFullReconcile {
+		if current != level {
+			c.Log.Infof("Changing CephBlockPool replication level from %d to %d", current, level)
+		} else {
+			c.Log.Debugf("Ensuring CephBlockPool replication level is %d", level)
+		}
 		c.Log.Infof("Changing CephBlockPool replication level from %d to %d", current, level)
 		pool.Spec.Replicated.Size = uint(level)
 		_, err := c.Config.CephV1.CephBlockPools(RookCephNS).Update(pool)
@@ -154,7 +159,7 @@ func (c *Controller) SetPoolReplication(name string, level int) error {
 }
 
 // SetSharedFilesystemReplication ignores NotFound errors.
-func (c *Controller) SetFilesystemReplication(name string, level int) error {
+func (c *Controller) SetFilesystemReplication(name string, level int, doFullReconcile bool) error {
 	if name == "" {
 		return nil
 	}
@@ -180,8 +185,12 @@ func (c *Controller) SetFilesystemReplication(name string, level int) error {
 		changed = true
 	}
 
-	if changed {
-		c.Log.Infof("Changing CephFilesystem pool replication level from %d to %d", current, level)
+	if changed || doFullReconcile {
+		if changed {
+			c.Log.Infof("Changing CephFilesystem pool replication level from %d to %d", current, level)
+		} else {
+			c.Log.Debugf("Ensuring CephFilesystem pool replication level is %d", level)
+		}
 		_, err := c.Config.CephV1.CephFilesystems("rook-ceph").Update(fs)
 		if err != nil {
 			return errors.Wrapf(err, "update Filesystem %s", name)
@@ -214,7 +223,7 @@ func (c *Controller) SetFilesystemReplication(name string, level int) error {
 }
 
 // SetObjectStoreReplication ignores NotFound errors.
-func (c *Controller) SetObjectStoreReplication(name string, level int) error {
+func (c *Controller) SetObjectStoreReplication(name string, level int, doFullReconcile bool) error {
 	if name == "" {
 		return nil
 	}
@@ -240,12 +249,16 @@ func (c *Controller) SetObjectStoreReplication(name string, level int) error {
 		changed = true
 	}
 
-	if changed {
+	if changed || doFullReconcile {
 		minSize := 1
 		if level > 1 {
 			minSize = 2
 		}
-		c.Log.Infof("Changing CephObjectStore pool replication level from %d to %d", current, level)
+		if changed {
+			c.Log.Infof("Changing CephObjectStore pool replication level from %d to %d", current, level)
+		} else {
+			c.Log.Debugf("Ensuring CephOjbectStore pool replication level is %d", level)
+		}
 		_, err := c.Config.CephV1.CephObjectStores(RookCephNS).Update(os)
 		if err != nil {
 			return errors.Wrapf(err, "update CephObjectStore %s", name)

--- a/pkg/cluster/rook_ceph.go
+++ b/pkg/cluster/rook_ceph.go
@@ -129,7 +129,6 @@ func (c *Controller) SetBlockPoolReplication(name string, level int, doFullRecon
 		} else {
 			c.Log.Debugf("Ensuring CephBlockPool replication level is %d", level)
 		}
-		c.Log.Infof("Changing CephBlockPool replication level from %d to %d", current, level)
 		pool.Spec.Replicated.Size = uint(level)
 		_, err := c.Config.CephV1.CephBlockPools(RookCephNS).Update(pool)
 		if err != nil {

--- a/pkg/ekcoops/poll.go
+++ b/pkg/ekcoops/poll.go
@@ -11,6 +11,7 @@ import (
 func (o *Operator) Poll(ctx context.Context, interval time.Duration) {
 	ticker := time.NewTicker(interval)
 
+	i := 0
 	for {
 		select {
 		case <-ticker.C:
@@ -19,7 +20,8 @@ func (o *Operator) Poll(ctx context.Context, interval time.Duration) {
 				o.log.Infof("Skipping reconcile: failed to list nodes: %v", err)
 				continue
 			}
-			err = o.Reconcile(nodeList.Items)
+			doFullReconcile := i%60 == 0
+			err = o.Reconcile(nodeList.Items, doFullReconcile)
 			if err != nil {
 				o.log.Infof("Reconcile failed: %v", err)
 				continue
@@ -28,5 +30,6 @@ func (o *Operator) Poll(ctx context.Context, interval time.Duration) {
 			ticker.Stop()
 			return
 		}
+		i++
 	}
 }


### PR DESCRIPTION
This handles upgrades from previous versions that did not scale the RGW
pool and ensures the correct level is eventually set if there are errors
during the first apply.