### PR TITLE
OSD host count controls replication level

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,7 @@
 
 EKCO is responsible for performing various operations to maintain the health of a kURL cluster.
 
-### Purge nodes
-
-In an HA Kubernetes cluster the EKCO operator will automatically purge failed nodes that have been unreachable for more than `node_unreachable_toleration` (default 1h). The following steps will be taken during a purge:
-
-1. Delete the Deployment resource for the OSD from the rook-ceph namespace
-1. Exec into the Rook operator pod and run the command `ceph osd purge <id>`
-1. Delete the Node resource
-1. Remove the node from the CephCluster resource named rook-ceph in the rook-ceph namespace unless storage is managed automatically with `useAllNodes: true`
-1. (Masters only) Connect to the etcd cluster and remove the peer
-1. (Masters only) Remove the apiEndpoint for the node from the kubeadm-config ConfigMap in the kube-system namespace
-
-### Rook
-
-The EKCO operator is responsible for appending nodes to the CephCluster `storage.nodes` setting to include the node in the list of nodes used by Ceph for storage. This operation will only append nodes. Removing nodes is done during purge.
-
-EKCO is also responsible for adjusting the Ceph block pool, filesystem and object store replication factor up and down in accordance with the size of the cluster from `min_ceph_pool_replication` (default 1) to `max_ceph_pool_replication` (default 3).
+[Documentation](https://kurl.sh/docs/add-ons/ekco)
 
 ## Test manually
 

--- a/pkg/cluster/rook_ceph_test.go
+++ b/pkg/cluster/rook_ceph_test.go
@@ -1,0 +1,55 @@
+package cluster
+
+import "testing"
+
+func TestParseCephOSDStatusHosts(t *testing.T) {
+	tests := []struct {
+		name  string
+		s     string
+		count int
+	}{
+		{
+			name: "2 unique",
+			s: `
+ID  HOST             USED  AVAIL  WR OPS  WR DATA  RD OPS  RD DATA  STATE
+ 0  areed-aka-36xk  9.77G   190G      0      123k      6      304   exists,up
+ 1  areed-aka-cpnv  9.77G   190G      0     2457       2      113   exists,up`,
+			count: 2,
+		},
+		{
+			name:  "0",
+			s:     `ID  HOST             USED  AVAIL  WR OPS  WR DATA  RD OPS  RD DATA  STATE`,
+			count: 0,
+		},
+		{
+			name: "5 unique of 11",
+			s: `
+ID  HOST             USED  AVAIL  WR OPS  WR DATA  RD OPS  RD DATA  STATE
+ 0  areed-aka-36xk  9.77G   190G      0      123k      6      304   exists,up
+ 1  areed-aka-cpnv  9.77G   190G      0     2457       2      113   exists,up
+ 2  areed-aka-abcd  9.77G   190G      0      123k      6      304   exists,up
+ 3  areed-aka-abce  9.77G   190G      0      123k      6      304   exists,up
+ 4  areed-aka-abdf  9.77G   190G      0      123k      6      304   exists,up
+ 5  areed-aka-36xk  9.77G   190G      0      123k      6      304   exists,up
+ 6  areed-aka-cpnv  9.77G   190G      0      123k      6      304   exists,up
+ 7  areed-aka-abcd  9.77G   190G      0      123k      6      304   exists,up
+ 8  areed-aka-abce  9.77G   190G      0      123k      6      304   exists,up
+ 9  areed-aka-abdf  9.77G   190G      0      123k      6      304   exists,up
+10  areed-aka-36xk  9.77G   190G      0      123k      6      304   exists,up`,
+			count: 5,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := parseCephOSDStatusHosts(test.s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			count := len(actual)
+			if test.count != count {
+				t.Errorf("got %d, want %d", count, test.count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously the replication level was based on the number of nodes in the cluster. That works for the filestore since a single directory on every node is used but with Rook 1.4 there may be nodes that don't have a block device attached and not have an OSD on them.