### PR TITLE
Set mon count on 1.0.4

### DIFF
--- a/cmd/ekco/cli/purge_node.go
+++ b/cmd/ekco/cli/purge_node.go
@@ -61,14 +61,14 @@ func purgeNode(nodeName string, config *ekcoops.Config, clusterController *clust
 	readyMasters, readyWorkers := util.NodeReadyCounts(nodeList.Items)
 	if readyMasters <= config.MinReadyMasterNodes {
 		for _, node := range nodeList.Items {
-			if node.Name == nodeName && util.NodeIsMaster(node) {
+			if node.Name == nodeName && util.NodeIsMaster(node) && util.NodeIsReady(node) {
 				return fmt.Errorf("cannot purge master: %d ready masters", readyMasters)
 			}
 		}
 	}
 	if readyWorkers <= config.MinReadyWorkerNodes {
 		for _, node := range nodeList.Items {
-			if node.Name == nodeName && !util.NodeIsMaster(node) {
+			if node.Name == nodeName && !util.NodeIsMaster(node) && util.NodeIsReady(node) {
 				return fmt.Errorf("cannot purge worker: %d ready workers", readyWorkers)
 			}
 		}


### PR DESCRIPTION
This accomodates for clobbering the preferredCount since it does not
exist in the v1 type.
Never scale mon count down.
Never scale pool replication level down.