### PR TITLE
Added to check for control-plane labels in addition to master labels to support k8s 1.24.0

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -38,8 +38,16 @@ spec:
     spec:
       serviceAccountName: ekco
       restartPolicy: Always
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity: 
+        nodeAffinity: 
+          requiredDuringSchedulingIgnoredDuringExecution: 
+            nodeSelectorTerms: 
+            - matchExpressions: 
+              - key: node-role.kubernetes.io/control-plane 
+                operator: Exists 
+            - matchExpressions: 
+              - key: node-role.kubernetes.io/master 
+                operator: Exists
       containers:
         - name: ekc-operator
           image: replicated/ekco

--- a/pkg/cluster/certs.go
+++ b/pkg/cluster/certs.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
 )
 
 var errPodFailed error = errors.New("pod failed")
@@ -65,8 +67,12 @@ func (c *Controller) RotateAllCerts(ctx context.Context) error {
 	if err := c.deletePods(RotateCertsSelector); err != nil {
 		c.Log.Warnf("Failed to delete rotate pods: %v", err)
 	}
+	primaryRoleLabel, err := c.getPrimaryRoleLabel()
+	if err != nil {
+		return errors.Wrap(err, "unable to get primary role label")
+	}
 	opts := metav1.ListOptions{
-		LabelSelector: PrimaryRoleLabel,
+		LabelSelector: primaryRoleLabel,
 	}
 	node, err := c.Config.Client.CoreV1().Nodes().List(context.TODO(), opts)
 	if err != nil {
@@ -111,6 +117,12 @@ func (c *Controller) deletePods(selector labels.Selector) error {
 }
 
 func (c *Controller) getRotateCertsPodConfig(nodeName string) *corev1.Pod {
+
+	primaryRoleLabel, err := c.getPrimaryRoleLabel()
+	if err != nil {
+		//TODO add log
+		return nil
+	}
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "rotate-certs-",
@@ -125,7 +137,7 @@ func (c *Controller) getRotateCertsPodConfig(nodeName string) *corev1.Pod {
 			},
 			Tolerations: []corev1.Toleration{
 				{
-					Key:      PrimaryRoleLabel,
+					Key:      primaryRoleLabel,
 					Effect:   corev1.TaintEffectNoSchedule,
 					Operator: corev1.TolerationOpExists,
 				},
@@ -219,4 +231,31 @@ func (c *Controller) logPodResults(namespace, name string) {
 			c.Log.Debug(line)
 		}
 	}
+}
+
+func (c *Controller) getPrimaryRoleLabel() (string, error) {
+	primaryRoleLabel := ""
+	clientset, err := kubernetes.NewForConfig(c.Config.ClientConfig)
+	if err != nil {
+		return primaryRoleLabel, errors.Wrap(err, "failed to create kubernetes clientset")
+	}
+	currentK8sVersion, err := clientset.ServerVersion()
+	if err != nil {
+		return primaryRoleLabel, errors.Wrap(err, "failed to get k8s version")
+	}
+	toleratedVersion, err := semver.ParseTolerant(currentK8sVersion.String())
+	if err != nil {
+		return primaryRoleLabel, errors.Wrap(err, "failed to parse k8s version")
+	}
+	compareK8sVersion, err := semver.Make("1.24.0")
+	if err != nil {
+		return primaryRoleLabel, errors.Wrap(err, "failed to make k8s version")
+	}
+	if toleratedVersion.GE(compareK8sVersion) {
+		primaryRoleLabel = "node-role.kubernetes.io/control-plane"
+	} else {
+		primaryRoleLabel = "node-role.kubernetes.io/master"
+	}
+	return primaryRoleLabel, nil
+
 }

--- a/pkg/cluster/certs.go
+++ b/pkg/cluster/certs.go
@@ -66,11 +66,20 @@ func (c *Controller) RotateAllCerts(ctx context.Context) error {
 		c.Log.Warnf("Failed to delete rotate pods: %v", err)
 	}
 	opts := metav1.ListOptions{
-		LabelSelector: "node-role.kubernetes.io/master=,node-role.kubernetes.io/control-plane=",
+		LabelSelector: "node-role.kubernetes.io/master=",
 	}
 	node, err := c.Config.Client.CoreV1().Nodes().List(context.TODO(), opts)
 	if err != nil {
 		return errors.Wrap(err, "list primary nodes")
+	}
+	if len(node.Items) == 0 {
+		opts = metav1.ListOptions{
+			LabelSelector: "node-role.kubernetes.io/control-plane=",
+		}
+		node, err = c.Config.Client.CoreV1().Nodes().List(context.TODO(), opts)
+		if err != nil {
+			return errors.Wrap(err, "list primary nodes")
+		}
 	}
 	for i, node := range node.Items {
 		c.Log.Debugf("Running certificate rotation task on node %s", node.Name)

--- a/pkg/cluster/constants.go
+++ b/pkg/cluster/constants.go
@@ -11,7 +11,6 @@ const (
 
 	RookCephObjectStoreRootPool = ".rgw.root"
 
-	PrimaryRoleLabel         = "node-role.kubernetes.io/master"
 	RotateCertsLabel         = "kurl.sh/task"
 	RotateCertsValue         = "rotate-certs"
 	RotateCertsLastAttempted = "rotate-certs-last-attempted"

--- a/pkg/cluster/internallb.go
+++ b/pkg/cluster/internallb.go
@@ -65,14 +65,8 @@ func (c *Controller) UpdateInternalLB(ctx context.Context, nodes []corev1.Node) 
 	}
 	var primaryHosts []string
 
-	primaryRoleLabel, err := c.getPrimaryRoleLabel()
-	if err != nil {
-		c.Log.Errorf("Failed to get primary role label: %v", err)
-		return nil
-	}
-
 	for _, node := range nodes {
-		if _, ok := node.ObjectMeta.Labels[primaryRoleLabel]; !ok {
+		if !util.NodeIsMaster(node) {
 			continue
 		}
 		if host := util.NodeInternalIP(node); host != "" {
@@ -120,12 +114,6 @@ func (c *Controller) getUpdateInternalLBPod(nodeName string, primaries ...string
 
 	hosts := strings.Join(primaries, ",")
 
-	primaryRoleLabel, err := c.getPrimaryRoleLabel()
-	if err != nil {
-		//TODO log error
-		return nil
-	}
-
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "update-haproxy-",
@@ -140,7 +128,12 @@ func (c *Controller) getUpdateInternalLBPod(nodeName string, primaries ...string
 			},
 			Tolerations: []corev1.Toleration{
 				{
-					Key:      primaryRoleLabel,
+					Key:      "node-role.kubernetes.io/master",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "node-role.kubernetes.io/control-plane",
 					Effect:   corev1.TaintEffectNoSchedule,
 					Operator: corev1.TolerationOpExists,
 				},

--- a/pkg/cluster/internallb.go
+++ b/pkg/cluster/internallb.go
@@ -67,7 +67,9 @@ func (c *Controller) UpdateInternalLB(ctx context.Context, nodes []corev1.Node) 
 
 	for _, node := range nodes {
 		if _, ok := node.ObjectMeta.Labels[util.MasterRoleLabel]; !ok {
-			continue
+			if _, ok := node.ObjectMeta.Labels[util.ControlPlaneRoleLabel]; !ok {
+				continue
+			}
 		}
 		if host := util.NodeInternalIP(node); host != "" {
 			primaryHosts = append(primaryHosts, host)

--- a/pkg/cluster/set_kubeconfig_server.go
+++ b/pkg/cluster/set_kubeconfig_server.go
@@ -54,7 +54,12 @@ func (c *Controller) setKubeconfigServerPod(nodeName string, server string, admi
 			},
 			Tolerations: []corev1.Toleration{
 				{
-					Key:      PrimaryRoleLabel,
+					Key:      "node-role.kubernetes.io/master",
+					Effect:   corev1.TaintEffectNoSchedule,
+					Operator: corev1.TolerationOpExists,
+				},
+				{
+					Key:      "node-role.kubernetes.io/control-plane",
 					Effect:   corev1.TaintEffectNoSchedule,
 					Operator: corev1.TolerationOpExists,
 				},

--- a/pkg/util/node.go
+++ b/pkg/util/node.go
@@ -5,6 +5,7 @@ import (
 )
 
 const MasterRoleLabel = "node-role.kubernetes.io/master"
+const ControlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
 const UnreachableTaint = "node.kubernetes.io/unreachable"
 const NotReadyTaint = "node.kubernetes.io/not-ready"
 const NetworkUnavailableTaint = "node.kubernetes.io/network-unavailable"
@@ -27,7 +28,14 @@ func NodeIsReady(node v1.Node) bool {
 }
 
 func NodeIsMaster(node v1.Node) bool {
-	_, ok := node.ObjectMeta.Labels[MasterRoleLabel]
+	ok := false
+
+	if _, ok = node.ObjectMeta.Labels[MasterRoleLabel]; ok {
+		return ok
+	}
+	if _, ok = node.ObjectMeta.Labels[ControlPlaneRoleLabel]; ok {
+		return ok
+	}
 	return ok
 }
 


### PR DESCRIPTION
Added to check for control-plane labels in addition to master labels to support k8s 1.24.0

SC-48706

https://kubernetes.io/blog/2022/04/07/upcoming-changes-in-kubernetes-1-24/

> The master label is no longer present on kubeadm control plane nodes. For new clusters, the label ‘node-role.kubernetes.io/master’ will no longer be added to control plane nodes, only the label ‘node-role.kubernetes.io/control-plane’ will be added. 