### PR TITLE
EKCO haproxy causes api requests to timeout

### DIFF
--- a/cmd/ekco/cli/generate-haproxy-manifest.go
+++ b/cmd/ekco/cli/generate-haproxy-manifest.go
@@ -20,7 +20,7 @@ func GenerateHAProxyManifestCmd(v *viper.Viper) *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			err := internallb.GenerateHAProxyManifest(filename, image, *primaries...)
+			err := internallb.GenerateHAProxyManifest(filename, image)
 			if err != nil {
 				return err
 			}
@@ -29,9 +29,12 @@ func GenerateHAProxyManifestCmd(v *viper.Viper) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringSliceVar(primaries, "primary-host", []string{}, "Kubernetes API server IP or hostname")
 	cmd.Flags().StringVar(&filename, "file", "/etc/kubernetes/manifests/haproxy", "Filename for the haproxy static pod manifest")
 	cmd.Flags().StringVar(&image, "image", "haproxy:lts-alpine", "Container image for the haproxy static pod manifest")
+
+	cmd.Flags().StringSliceVar(primaries, "primary-host", []string{}, "Kubernetes API server IP or hostname")
+	cmd.Flags().MarkDeprecated("primary-host", "this flag is no longer used")
+	cmd.Flags().MarkHidden("primary-host")
 
 	return cmd
 }

--- a/deploy/serviceaccount.yaml
+++ b/deploy/serviceaccount.yaml
@@ -61,6 +61,11 @@ rules:
     verbs:
       - get
       - update
+  - apiGroups: [""]
+    resources:
+      - pods/exec
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/pkg/cluster/certs.go
+++ b/pkg/cluster/certs.go
@@ -62,7 +62,7 @@ func (c *Controller) CheckRotateCertsDue(reset bool) (bool, error) {
 // This launches a pod on each primary to mount /etc/kubernetes and rotate the certs.
 // It leaves the pods up if any fail.
 func (c *Controller) RotateAllCerts(ctx context.Context) error {
-	if err := c.deletePods(RotateCertsSelector); err != nil {
+	if err := c.deletePods(c.Config.RotateCertsNamespace, RotateCertsSelector); err != nil {
 		c.Log.Warnf("Failed to delete rotate pods: %v", err)
 	}
 	opts := metav1.ListOptions{
@@ -104,19 +104,19 @@ func (c *Controller) RotateAllCerts(ctx context.Context) error {
 		c.logPodResults(c.Config.RotateCertsNamespace, pod.Name)
 	}
 
-	if err := c.deletePods(RotateCertsSelector); err != nil {
+	if err := c.deletePods(c.Config.RotateCertsNamespace, RotateCertsSelector); err != nil {
 		c.Log.Warnf("Failed to delete rotate pods: %v", err)
 	}
 
 	return nil
 }
 
-func (c *Controller) deletePods(selector labels.Selector) error {
+func (c *Controller) deletePods(namespace string, selector labels.Selector) error {
 	options := metav1.ListOptions{
 		LabelSelector: selector.String(),
 	}
 
-	return c.Config.Client.CoreV1().Pods(c.Config.RotateCertsNamespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, options)
+	return c.Config.Client.CoreV1().Pods(namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, options)
 }
 
 func (c *Controller) getRotateCertsPodConfig(nodeName string) *corev1.Pod {

--- a/pkg/cluster/set_kubeconfig_server.go
+++ b/pkg/cluster/set_kubeconfig_server.go
@@ -29,7 +29,7 @@ func (c *Controller) SetKubeconfigServer(ctx context.Context, node corev1.Node, 
 		return errors.Wrapf(err, "run set-kubeconfig-server pod on node %s", node.Name)
 	}
 
-	if err := c.deletePods(SetKubeconfigServerSelector); err != nil {
+	if err := c.deletePods(c.Config.HostTaskNamespace, SetKubeconfigServerSelector); err != nil {
 		c.Log.Warnf("Failed to delete set-kubeconfig-server pods: %v", err)
 	}
 

--- a/pkg/internallb/haproxy.cfg
+++ b/pkg/internallb/haproxy.cfg
@@ -10,36 +10,29 @@ global
 #---------------------------------------------------------------------
 # common defaults that all the 'listen' and 'backend' sections will
 # use if not designated in their block
+# borrowed from https://github.com/openshift/machine-config-operator/blob/9674df13d76e3832c5b8404083fb6218a09503f8/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
 #---------------------------------------------------------------------
 defaults
-    mode                    http
-    log                     global
-    option                  httplog
-    option                  dontlognull
-    option http-server-close
-    option forwardfor       except 127.0.0.0/8
-    option                  redispatch
-    retries                 1
-    timeout http-request    10s
-    timeout queue           20s
-    timeout connect         5s
-    timeout client          20s
-    timeout server          20s
-    timeout http-keep-alive 10s
-    timeout check           10s
+    maxconn 20000
+    mode    tcp
+    option  dontlognull
+    retries 3
+    timeout http-request 30s
+    timeout queue        1m
+    timeout connect      10s
+    timeout client       86400s
+    timeout server       86400s
+    timeout tunnel       86400s
 
 frontend kubernetes-api
-    bind 0.0.0.0:6444
-    mode tcp
+    bind 0.0.0.0:6444 v4v6
     option tcplog
     default_backend kubernetes-primaries
 
 backend kubernetes-primaries
-    option httpchk GET /healthz
-    http-check expect status 200
-    mode tcp
-    option ssl-hello-chk
+    option  httpchk GET /readyz HTTP/1.0
+    option  log-health-checks
     balance roundrobin
 {{- range $i, $host := .Primaries }}
-        server k8s-primary-{{$i}} {{$host}}:6443 check fall 3 rise 2
+    server k8s-primary-{{$i}} {{$host}}:6443 weight 1 verify none check check-ssl inter 1s fall 2 rise 3
 {{- end }}

--- a/pkg/internallb/haproxy.yaml
+++ b/pkg/internallb/haproxy.yaml
@@ -3,13 +3,13 @@ kind: Pod
 metadata:
   name: haproxy
   namespace: kube-system
+  labels:
+    app: kurl-haproxy
+    fileversion: "{{ .Fileversion }}"
 spec:
   containers:
   - image: "{{ .Image }}"
     name: haproxy
-    env:
-    - name: HAPROXY_CONFIG_HASH
-      value: "{{ .ConfigHash }}"
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/pkg/internallb/haproxy_test.go
+++ b/pkg/internallb/haproxy_test.go
@@ -1,6 +1,7 @@
 package internallb
 
 import (
+	_ "embed"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,45 +27,38 @@ global
 #---------------------------------------------------------------------
 # common defaults that all the 'listen' and 'backend' sections will
 # use if not designated in their block
+# borrowed from https://github.com/openshift/machine-config-operator/blob/9674df13d76e3832c5b8404083fb6218a09503f8/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml
 #---------------------------------------------------------------------
 defaults
-    mode                    http
-    log                     global
-    option                  httplog
-    option                  dontlognull
-    option http-server-close
-    option forwardfor       except 127.0.0.0/8
-    option                  redispatch
-    retries                 1
-    timeout http-request    10s
-    timeout queue           20s
-    timeout connect         5s
-    timeout client          20s
-    timeout server          20s
-    timeout http-keep-alive 10s
-    timeout check           10s
+    maxconn 20000
+    mode    tcp
+    option  dontlognull
+    retries 3
+    timeout http-request 30s
+    timeout queue        1m
+    timeout connect      10s
+    timeout client       86400s
+    timeout server       86400s
+    timeout tunnel       86400s
 
 frontend kubernetes-api
-    bind 0.0.0.0:6444
-    mode tcp
+    bind 0.0.0.0:6444 v4v6
     option tcplog
     default_backend kubernetes-primaries
 
 backend kubernetes-primaries
-    option httpchk GET /healthz
-    http-check expect status 200
-    mode tcp
-    option ssl-hello-chk
+    option  httpchk GET /readyz HTTP/1.0
+    option  log-health-checks
     balance roundrobin
-        server k8s-primary-0 10.128.0.3:6443 check fall 3 rise 2
-        server k8s-primary-1 10.128.0.4:6443 check fall 3 rise 2
+    server k8s-primary-0 10.128.0.3:6443 weight 1 verify none check check-ssl inter 1s fall 2 rise 3
+    server k8s-primary-1 10.128.0.4:6443 weight 1 verify none check check-ssl inter 1s fall 2 rise 3
 `
 
 	assert.Equal(t, expect, string(out))
 }
 
 func TestGenerateHAProxyManifest(t *testing.T) {
-	out, err := generateHAProxyManifest("haproxy:1.1.1", "5b02714")
+	out, err := generateHAProxyManifest("haproxy:1.1.1", 0)
 	assert.NoError(t, err)
 
 	expect := `apiVersion: v1
@@ -72,13 +66,13 @@ kind: Pod
 metadata:
   name: haproxy
   namespace: kube-system
+  labels:
+    app: kurl-haproxy
+    fileversion: "0"
 spec:
   containers:
   - image: "haproxy:1.1.1"
     name: haproxy
-    env:
-    - name: HAPROXY_CONFIG_HASH
-      value: "5b02714"
     livenessProbe:
       failureThreshold: 8
       httpGet:
@@ -99,4 +93,60 @@ spec:
 status: {}
 `
 	assert.Equal(t, expect, string(out))
+}
+
+func Test_getFileversion(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents []byte
+		want     int
+	}{
+		{
+			name: "missing",
+			contents: []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: haproxy
+  namespace: kube-system
+spec:`),
+			want: 0,
+		},
+		{
+			name: "zero",
+			contents: []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: haproxy
+  namespace: kube-system
+  labels:
+    app: kurl-haproxy
+    # when making changes to the file that need to be synchronized, increment
+    # fileversion number
+    fileversion: "0"
+spec:`),
+			want: 0,
+		},
+		{
+			name: "one",
+			contents: []byte(`apiVersion: v1
+kind: Pod
+metadata:
+  name: haproxy
+  namespace: kube-system
+  labels:
+    app: kurl-haproxy
+    # when making changes to the file that need to be synchronized, increment
+    # fileversion number
+    fileversion: "1"
+spec:`),
+			want: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getFileversion(tt.contents); got != tt.want {
+				t.Errorf("getFileversion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
timeout client|server 20s in haproxy.cfg causes long running requests to timeout when no data is sent over connection.

since i could not find the source of our haproxy.cfg i [borrowed from openshift](https://github.com/openshift/machine-config-operator/blob/9674df13d76e3832c5b8404083fb6218a09503f8/templates/master/00-master/on-prem/files/haproxy-haproxy.yaml).

additionally further connection dropping and downtime is caused by manifest update which causes pod to get recreated when new primaries are added. rather than update the manifest with config hash i use SIGHUP to reload.