### PR TITLE
Update internal load balancer job should use correct haproxy image

### DIFF
--- a/cmd/ekco/cli/generate-haproxy-manifest.go
+++ b/cmd/ekco/cli/generate-haproxy-manifest.go
@@ -29,7 +29,7 @@ func GenerateHAProxyManifestCmd(v *viper.Viper) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&filename, "file", "/etc/kubernetes/manifests/haproxy", "Filename for the haproxy static pod manifest")
-	cmd.Flags().StringVar(&image, "image", "haproxy:lts-alpine", "Container image for the haproxy static pod manifest")
+	cmd.Flags().StringVar(&image, "image", internallb.HAProxyImage, "Container image for the haproxy static pod manifest")
 
 	cmd.Flags().StringSliceVar(primaries, "primary-host", []string{}, "Kubernetes API server IP or hostname")
 	cmd.Flags().MarkDeprecated("primary-host", "this flag is no longer used")

--- a/cmd/ekco/cli/init.go
+++ b/cmd/ekco/cli/init.go
@@ -92,6 +92,7 @@ func initClusterController(config *ekcoops.Config, log *zap.SugaredLogger) (*clu
 		ContourCertSecret:                     config.ContourCertSecret,
 		EnvoyCertSecret:                       config.EnvoyCertSecret,
 		EnableInternalLoadBalancer:            config.EnableInternalLoadBalancer,
+		InternalLoadBalancerHAProxyImage:      config.InternalLoadBalancerHAProxyImage,
 		HostTaskImage:                         config.HostTaskImage,
 		HostTaskNamespace:                     config.HostTaskNamespace,
 		AutoApproveKubeletCertSigningRequests: config.AutoApproveKubeletCertSigningRequests,

--- a/cmd/ekco/cli/operator.go
+++ b/cmd/ekco/cli/operator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ekco/pkg/ekcoops"
+	"github.com/replicatedhq/ekco/pkg/internallb"
 	"github.com/replicatedhq/ekco/pkg/logger"
 	"github.com/replicatedhq/ekco/pkg/webhook"
 	"github.com/spf13/cobra"
@@ -117,6 +118,7 @@ func OperatorCmd(v *viper.Viper) *cobra.Command {
 	cmd.Flags().String("host_task_namespace", "kurl", "Namespace where pods performing host tasks will run")
 	cmd.Flags().String("host_task_image", "replicated/ekco:latest", "Image to use in host task pods")
 	cmd.Flags().Bool("enable_internal_load_balancer", false, "Run haproxy on localhost forwarding to all in-cluster Kubernetes API servers")
+	cmd.Flags().String("internal_load_balancer_haproxy_image", internallb.HAProxyImage, "HAProxy container image to use for internal load balancer")
 	cmd.Flags().StringSlice("pod_image_overrides", nil, "Image to override in pods")
 	cmd.Flags().Bool("auto_approve_kubelet_csrs", false, "Enable auto approval of kubelet Certificate Signing Requests")
 

--- a/pkg/cluster/controller.go
+++ b/pkg/cluster/controller.go
@@ -45,6 +45,7 @@ type ControllerConfig struct {
 	HostTaskImage                         string
 	HostTaskNamespace                     string
 	EnableInternalLoadBalancer            bool
+	InternalLoadBalancerHAProxyImage      string
 	AutoApproveKubeletCertSigningRequests bool
 }
 

--- a/pkg/cluster/internallb.go
+++ b/pkg/cluster/internallb.go
@@ -177,6 +177,7 @@ func (c *Controller) sighupPods(namespace string, selector labels.Selector, cont
 func (c *Controller) getUpdateInternalLBPod(nodeName string, primaries ...string) *corev1.Pod {
 	namespace := c.Config.HostTaskNamespace
 	image := c.Config.HostTaskImage
+	haproxyImage := c.Config.InternalLoadBalancerHAProxyImage
 
 	hosts := strings.Join(primaries, ",")
 
@@ -230,7 +231,7 @@ func (c *Controller) getUpdateInternalLBPod(nodeName string, primaries ...string
 					Command: []string{
 						"/bin/bash",
 						"-c",
-						fmt.Sprintf("/usr/bin/ekco generate-haproxy-manifest --primary-host=%s --file /host/etc/kubernetes/manifests/haproxy.yaml", hosts),
+						fmt.Sprintf("/usr/bin/ekco generate-haproxy-manifest --primary-host=%s --file /host/etc/kubernetes/manifests/haproxy.yaml --image=%s", hosts, haproxyImage),
 					},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/ekcoops/config.go
+++ b/pkg/ekcoops/config.go
@@ -55,6 +55,7 @@ type Config struct {
 	ContourCertSecret                     string        `mapstructure:"contour_cert_secret"`
 	EnvoyCertSecret                       string        `mapstructure:"envoy_cert_secret"`
 	EnableInternalLoadBalancer            bool          `mapstructure:"enable_internal_load_balancer"`
+	InternalLoadBalancerHAProxyImage      string        `mapstructure:"internal_load_balancer_haproxy_image"`
 	InternalLoadBalancerPort              int           `mapstructure:"internal_load_balancer_port"`
 	HostTaskImage                         string        `mapstructure:"host_task_image"`
 	HostTaskNamespace                     string        `mapstructure:"host_task_namespace"`

--- a/pkg/internallb/haproxy.go
+++ b/pkg/internallb/haproxy.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
+const HAProxyImage = "haproxy:lts-alpine"
+
 //go:embed haproxy.cfg
 var haproxyCfg string
 var haproxyConfigTmpl = template.Must(template.New("").Parse(haproxyCfg))


### PR DESCRIPTION
The job is currently using the default image and reverting the haproxy pod image.