### PR TITLE
Fix docker build failure in github actions

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -11,8 +11,7 @@ COPY LICENSE LICENSE
 COPY cmd cmd
 COPY pkg pkg
 
-RUN --mount=type=cache,target=/root/.cache/go-build \
-    make build GIT_SHA=$git_sha VERSION=$version
+RUN make build GIT_SHA=$git_sha VERSION=$version
 
 
 FROM debian:buster-slim


### PR DESCRIPTION
Fix failure

https://github.com/replicatedhq/ekco/runs/8214360638?check_suite_focus=true

```
the --mount option requires BuildKit. Refer to https://docs.docker.com/go/buildkit/ to learn how to build images with BuildKit enabled
```