### PR TITLE
build(base-image): update os packages before copying the binary

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,7 +16,7 @@ RUN make build GIT_SHA=$git_sha VERSION=$version
 
 FROM debian:buster-slim
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get upgrade -qq && apt-get install -y --no-install-recommends \
     libgcrypt20 \
     libgnutls30 \
     libhogweed4 \


### PR DESCRIPTION
this commit runs an "apt-get upgrade" prior to copying ekco assets from the build image. this assures we will always get the most updated packages for the base os.