### PR TITLE
Get rook version from cluster rather than config

### DIFF
--- a/cmd/ekco/cli/init.go
+++ b/cmd/ekco/cli/init.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ekco/pkg/cluster"
 	"github.com/replicatedhq/ekco/pkg/ekcoops"
@@ -63,21 +62,11 @@ func initClusterController(config *ekcoops.Config, log *zap.SugaredLogger) (*clu
 		Resource: "alertmanagers",
 	})
 
-	rv := config.RookVersion
-	if rv == "" {
-		rv = "1.4.3"
-	}
-	rookVersion, err := semver.Parse(rv)
-	if err != nil {
-		return nil, errors.Wrap(err, "parse rook version")
-	}
-
 	return cluster.NewController(cluster.ControllerConfig{
 		Client:                                client,
 		ClientConfig:                          clientConfig,
 		CephV1:                                rookcephclient,
 		CertificatesDir:                       config.CertificatesDir,
-		RookVersion:                           rookVersion,
 		AlertManagerV1:                        alertManagerClient,
 		PrometheusV1:                          prometheusClient,
 		RookPriorityClass:                     config.RookPriorityClass,

--- a/pkg/cluster/contour_certs.go
+++ b/pkg/cluster/contour_certs.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/projectcontour/contour/pkg/certs"
+	"github.com/replicatedhq/ekco/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -81,7 +81,7 @@ func (c *Controller) shouldRotateContourCerts(caCert, contourCert, envoyCert *x5
 func (c *Controller) readContourCerts(contourNamespace, contourSecretName, envoySecretName string) (*x509.Certificate, *x509.Certificate, *x509.Certificate, error) {
 	contourSecret, err := c.Config.Client.CoreV1().Secrets(contourNamespace).Get(context.TODO(), contourSecretName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if util.IsNotFoundErr(err) {
 			return nil, nil, nil, nil
 		}
 		return nil, nil, nil, errors.Wrapf(err, "get secret %s/%s", contourNamespace, contourSecretName)
@@ -89,7 +89,7 @@ func (c *Controller) readContourCerts(contourNamespace, contourSecretName, envoy
 
 	envoySecret, err := c.Config.Client.CoreV1().Secrets(contourNamespace).Get(context.TODO(), envoySecretName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if util.IsNotFoundErr(err) {
 			return nil, nil, nil, nil
 		}
 		return nil, nil, nil, errors.Wrapf(err, "get secret %s/%s", contourNamespace, envoySecretName)

--- a/pkg/cluster/controller.go
+++ b/pkg/cluster/controller.go
@@ -27,7 +27,6 @@ type ControllerConfig struct {
 	AlertManagerV1                        dynamic.NamespaceableResourceInterface
 	PrometheusV1                          dynamic.NamespaceableResourceInterface
 	CertificatesDir                       string
-	RookVersion                           semver.Version
 	RookPriorityClass                     string
 	RotateCerts                           bool
 	RotateCertsImage                      string

--- a/pkg/cluster/internallb.go
+++ b/pkg/cluster/internallb.go
@@ -30,6 +30,7 @@ func (c *Controller) ReconcileInternalLB(ctx context.Context, nodes []corev1.Nod
 		if !util.IsNotFoundErr(err) {
 			return errors.Wrapf(err, "get configmap %s/%s", c.Config.HostTaskNamespace, UpdateInternalLBValue)
 		}
+
 		// create the configmap the first time
 		cm = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/internallb.go
+++ b/pkg/cluster/internallb.go
@@ -12,7 +12,6 @@ import (
 	"github.com/replicatedhq/ekco/pkg/k8s"
 	"github.com/replicatedhq/ekco/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -27,10 +26,10 @@ func (c *Controller) ReconcileInternalLB(ctx context.Context, nodes []corev1.Nod
 
 	client := c.Config.Client.CoreV1().ConfigMaps(c.Config.HostTaskNamespace)
 	cm, err := client.Get(context.TODO(), UpdateInternalLBValue, metav1.GetOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		return errors.Wrapf(err, "get configmap %s/%s", c.Config.HostTaskNamespace, UpdateInternalLBValue)
-	}
-	if k8serrors.IsNotFound(err) {
+	if err != nil {
+		if !util.IsNotFoundErr(err) {
+			return errors.Wrapf(err, "get configmap %s/%s", c.Config.HostTaskNamespace, UpdateInternalLBValue)
+		}
 		// create the configmap the first time
 		cm = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cluster/kotsadm_certs.go
+++ b/pkg/cluster/kotsadm_certs.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/replicatedhq/ekco/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
 	certutil "k8s.io/client-go/util/cert"
@@ -22,7 +22,7 @@ func (c *Controller) RotateKurlProxyCert() error {
 	// 1. Parse current cert from secret
 	secret, err := c.Config.Client.CoreV1().Secrets(ns).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if util.IsNotFoundErr(err) {
 			c.Log.Debugf("Kurl proxy cert secret does not exist, skipping renewal")
 			return nil
 		}
@@ -82,7 +82,7 @@ func (c *Controller) UpdateKubeletClientCertSecret() error {
 
 	secret, err := c.Config.Client.CoreV1().Secrets(ns).Get(context.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if util.IsNotFoundErr(err) {
 			c.Log.Debugf("Kubelet client secret does not exist, skipping update")
 			return nil
 		}

--- a/pkg/cluster/registry_cert.go
+++ b/pkg/cluster/registry_cert.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"github.com/replicatedhq/ekco/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/duration"
@@ -88,7 +88,7 @@ func (c *Controller) RotateRegistryCert() error {
 func (c *Controller) readRegistryCert(namespace, name string) (*x509.Certificate, error) {
 	secret, err := c.Config.Client.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		if k8serrors.IsNotFound(err) {
+		if util.IsNotFoundErr(err) {
 			return nil, nil
 		}
 		return nil, errors.Wrapf(err, "get secret %s/%s", namespace, name)

--- a/pkg/ekcoops/config.go
+++ b/pkg/ekcoops/config.go
@@ -31,7 +31,6 @@ type Config struct {
 	CephObjectStore        string `mapstructure:"ceph_object_store"`
 	MinCephPoolReplication int    `mapstructure:"min_ceph_pool_replication"`
 	MaxCephPoolReplication int    `mapstructure:"max_ceph_pool_replication"`
-	RookVersion            string `mapstructure:"rook_version"`
 	// when set, priority class to be applied to rook deployments and daemonsets
 	RookPriorityClass string `mapstructure:"rook_priority_class"`
 	// Whether to reconcile CephFilesystem MDS placement when the cluster is scaled beyond one

--- a/pkg/util/errors.go
+++ b/pkg/util/errors.go
@@ -2,18 +2,16 @@ package util
 
 import (
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 func IsNotFoundErr(err error) bool {
-	statusErr, ok := errors.Cause(err).(*apierrors.StatusError)
-	return ok && statusErr.Status().Reason == metav1.StatusReasonNotFound
+	return k8serrors.IsNotFound(errors.Cause(err))
 }
 
 func FilterOutErr(err error, fns ...utilerrors.Matcher) error {
-	return utilerrors.FilterOut(err, fns...)
+	return utilerrors.FilterOut(errors.Cause(err), fns...)
 }
 
 func FilterOutReasonNotFoundErr(err error) error {

--- a/pkg/util/semver.go
+++ b/pkg/util/semver.go
@@ -1,9 +1,0 @@
-package util
-
-import "github.com/blang/semver"
-
-var semverZero = semver.Version{}
-
-func SemverIsZero(version semver.Version) bool {
-	return semverZero.Equals(version)
-}

--- a/pkg/util/semver.go
+++ b/pkg/util/semver.go
@@ -1,0 +1,9 @@
+package util
+
+import "github.com/blang/semver"
+
+var semverZero = semver.Version{}
+
+func SemverIsZero(version semver.Version) bool {
+	return semverZero.Equals(version)
+}


### PR DESCRIPTION
When upgrading Rook and not EKCO, the config map is not overwritten by kURL so the Rook version is not reliable.

https://github.com/replicatedhq/kURL/blob/66491a41f4b6b1919e4f10c9fd8c73d1bb0078eb/addons/ekco/template/base/install.sh#L105

Instead get the Rook version from the cluster.