### PR TITLE
Ceph Quincy set pg_num_min to 8 for rgw metadata pools

### DIFF
--- a/pkg/cluster/constants.go
+++ b/pkg/cluster/constants.go
@@ -34,6 +34,15 @@ var (
 		"rgw.buckets.index",
 		"rgw.buckets.non-ec",
 	}
+	RookCephObjectStoreMetadataPoolsQuincy = []string{
+		// .rgw.root (rootPool) is appended to this slice where needed
+		"rgw.control",
+		"rgw.meta",
+		"rgw.log",
+		"rgw.buckets.index",
+		"rgw.buckets.non-ec",
+		"rgw.otp",
+	}
 	RookCephObjectStoreDataPools = []string{
 		"rgw.buckets.data",
 	}

--- a/pkg/cluster/controller.go
+++ b/pkg/cluster/controller.go
@@ -20,6 +20,7 @@ const (
 
 var Rookv14 = semver.MustParse("1.4.0")
 var Rookv19 = semver.MustParse("1.9.0")
+var CephQuincy = semver.MustParse("17.2.0")
 
 type ControllerConfig struct {
 	Client                                kubernetes.Interface

--- a/pkg/cluster/rook_ceph_test.go
+++ b/pkg/cluster/rook_ceph_test.go
@@ -647,9 +647,9 @@ func TestController_removeCephClusterStorageNode(t *testing.T) {
 func TestController_SetBlockPoolReplication(t *testing.T) {
 	type args struct {
 		rookVersion     semver.Version
+		cephVersion     semver.Version
 		name            string
 		level           int
-		cephcluster     *cephv1.CephCluster
 		doFullReconcile bool
 	}
 	tests := []struct {
@@ -684,9 +684,9 @@ func TestController_SetBlockPoolReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "replicapool",
 				level:           1,
-				cephcluster:     nil,
 				doFullReconcile: false,
 			},
 			want:      false,
@@ -717,9 +717,9 @@ func TestController_SetBlockPoolReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "replicapool",
 				level:           1,
-				cephcluster:     nil,
 				doFullReconcile: true,
 			},
 			want:      true,
@@ -750,9 +750,9 @@ func TestController_SetBlockPoolReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "replicapool",
 				level:           3,
-				cephcluster:     nil,
 				doFullReconcile: false,
 			},
 			want:      true,
@@ -770,7 +770,7 @@ func TestController_SetBlockPoolReplication(t *testing.T) {
 				},
 				Log: logger.NewDiscardLogger(),
 			}
-			got, err := c.SetBlockPoolReplication(tt.args.rookVersion, tt.args.name, tt.args.level, tt.args.cephcluster, tt.args.doFullReconcile)
+			got, err := c.SetBlockPoolReplication(tt.args.rookVersion, tt.args.cephVersion, tt.args.name, tt.args.level, tt.args.doFullReconcile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Controller.SetBlockPoolReplication() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -990,9 +990,9 @@ func TestController_ReconcileMgrCount(t *testing.T) {
 func TestController_SetFilesystemReplication(t *testing.T) {
 	type args struct {
 		rookVersion     semver.Version
+		cephVersion     semver.Version
 		name            string
 		level           int
-		cephcluster     *cephv1.CephCluster
 		doFullReconcile bool
 	}
 	tests := []struct {
@@ -1036,9 +1036,9 @@ func TestController_SetFilesystemReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "myfs",
 				level:           1,
-				cephcluster:     nil,
 				doFullReconcile: false,
 			},
 			want:      false,
@@ -1078,9 +1078,9 @@ func TestController_SetFilesystemReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "myfs",
 				level:           1,
-				cephcluster:     nil,
 				doFullReconcile: true,
 			},
 			want:      true,
@@ -1120,9 +1120,9 @@ func TestController_SetFilesystemReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "myfs",
 				level:           3,
-				cephcluster:     nil,
 				doFullReconcile: false,
 			},
 			want:      true,
@@ -1140,7 +1140,7 @@ func TestController_SetFilesystemReplication(t *testing.T) {
 				},
 				Log: logger.NewDiscardLogger(),
 			}
-			got, err := c.SetFilesystemReplication(tt.args.rookVersion, tt.args.name, tt.args.level, tt.args.cephcluster, tt.args.doFullReconcile)
+			got, err := c.SetFilesystemReplication(tt.args.rookVersion, tt.args.cephVersion, tt.args.name, tt.args.level, tt.args.doFullReconcile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Controller.SetFilesystemReplication() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1166,18 +1166,20 @@ func TestController_SetFilesystemReplication(t *testing.T) {
 func TestController_SetObjectStoreReplication(t *testing.T) {
 	type args struct {
 		rookVersion     semver.Version
+		cephVersion     semver.Version
 		name            string
 		level           int
-		cephcluster     *cephv1.CephCluster
 		doFullReconcile bool
 	}
 	tests := []struct {
-		name          string
-		rookResources []runtime.Object
-		args          args
-		want          bool
-		wantLevel     uint
-		wantErr       bool
+		name                    string
+		resources               []runtime.Object
+		rookResources           []runtime.Object
+		mockSyncExecutorExpects func(*mock_k8s.MockSyncExecutorInterface)
+		args                    args
+		want                    bool
+		wantLevel               uint
+		wantErr                 bool
 	}{
 		{
 			name: "objectstore replication should stay at 1, rook version 1.9.12",
@@ -1207,9 +1209,9 @@ func TestController_SetObjectStoreReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "my-store",
 				level:           1,
-				cephcluster:     nil,
 				doFullReconcile: false,
 			},
 			want:      false,
@@ -1244,9 +1246,9 @@ func TestController_SetObjectStoreReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "my-store",
 				level:           1,
-				cephcluster:     nil,
 				doFullReconcile: true,
 			},
 			want:      true,
@@ -1281,27 +1283,109 @@ func TestController_SetObjectStoreReplication(t *testing.T) {
 			},
 			args: args{
 				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("16.2.6"),
 				name:            "my-store",
 				level:           3,
-				cephcluster:     nil,
 				doFullReconcile: false,
 			},
 			want:      true,
 			wantLevel: 3,
 			wantErr:   false,
 		},
+		{
+			name: "should reconcile object store metadata pools pg_num_min for ceph quincy, do full reconcile",
+			resources: []runtime.Object{
+				&corev1.Pod{
+					TypeMeta: metav1.TypeMeta{Kind: "Pod", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rook-ceph-tools-5b8b8b8b8b-5b8b8",
+						Namespace: "rook-ceph",
+						Labels: map[string]string{
+							"app": "rook-ceph-tools",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "rook-ceph-tools",
+							},
+						},
+					},
+				},
+			},
+			rookResources: []runtime.Object{
+				&cephv1.CephObjectStore{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "ceph.rook.io/v1",
+						Kind:       "CephObjectStore",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-store",
+						Namespace: "rook-ceph",
+					},
+					Spec: cephv1.ObjectStoreSpec{
+						MetadataPool: cephv1.PoolSpec{
+							Replicated: cephv1.ReplicatedSpec{
+								Size: 1,
+							},
+						},
+						DataPool: cephv1.PoolSpec{
+							Replicated: cephv1.ReplicatedSpec{
+								Size: 1,
+							},
+						},
+					},
+				},
+			},
+			mockSyncExecutorExpects: func(m *mock_k8s.MockSyncExecutorInterface) {
+				for _, name := range []string{
+					".rgw.root",
+					"my-store.rgw.control",
+					"my-store.rgw.meta",
+					"my-store.rgw.log",
+					"my-store.rgw.buckets.index",
+					"my-store.rgw.buckets.non-ec",
+					"my-store.rgw.otp",
+				} {
+					m.EXPECT().ExecContainer(gomock.Any(), "rook-ceph", "rook-ceph-tools-5b8b8b8b8b-5b8b8", "rook-ceph-tools", "ceph", "osd", "pool", "set", name, "pg_num_min", "8").
+						Return(0, "", "set pool 7 pg_num_min to 8", nil)
+				}
+			},
+			args: args{
+				rookVersion:     semver.MustParse("1.9.12"),
+				cephVersion:     semver.MustParse("17.2.5-0"),
+				name:            "my-store",
+				level:           1,
+				doFullReconcile: true,
+			},
+			want:      true,
+			wantLevel: 1,
+			wantErr:   false,
+		},
 		// TODO: rookVersion 1.0.4
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			m := mock_k8s.NewMockSyncExecutorInterface(ctrl)
+			if tt.mockSyncExecutorExpects != nil {
+				tt.mockSyncExecutorExpects(m)
+			}
+
+			clientset := fake.NewSimpleClientset(tt.resources...)
 			rookClientset := rookfake.NewSimpleClientset(tt.rookResources...)
 			c := &Controller{
 				Config: ControllerConfig{
+					Client: clientset,
 					CephV1: rookClientset.CephV1(),
 				},
-				Log: logger.NewDiscardLogger(),
+				SyncExecutor: m,
+				Log:          logger.NewDiscardLogger(),
 			}
-			got, err := c.SetObjectStoreReplication(tt.args.rookVersion, tt.args.name, tt.args.level, tt.args.cephcluster, tt.args.doFullReconcile)
+
+			got, err := c.SetObjectStoreReplication(tt.args.rookVersion, tt.args.cephVersion, tt.args.name, tt.args.level, tt.args.doFullReconcile)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Controller.SetObjectStoreReplication() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/ekcoops/operator.go
+++ b/pkg/ekcoops/operator.go
@@ -12,6 +12,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/replicatedhq/ekco/pkg/cluster"
+	"github.com/replicatedhq/ekco/pkg/rook"
 	"github.com/replicatedhq/ekco/pkg/util"
 	"go.uber.org/zap"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -231,23 +232,29 @@ func (o *Operator) adjustPoolReplicationLevels(rookVersion semver.Version, numNo
 
 	var multiErr error
 
+	cephVersion := semver.Version{}
 	cephcluster, err := o.controller.GetCephCluster(context.TODO())
 	if err != nil {
 		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "get CephCluster config"))
+	} else {
+		cephVersion, err = rook.GetCephVersion(*cephcluster)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, errors.Wrapf(err, "get ceph version"))
+		}
 	}
 
-	didUpdate, err := o.controller.SetBlockPoolReplication(rookVersion, o.config.CephBlockPool, factor, cephcluster, doFullReconcile)
+	didUpdate, err := o.controller.SetBlockPoolReplication(rookVersion, cephVersion, o.config.CephBlockPool, factor, doFullReconcile)
 	if err != nil {
 		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "set pool %s replication to %d", o.config.CephBlockPool, factor))
 	}
 
-	ok, err := o.controller.SetFilesystemReplication(rookVersion, o.config.CephFilesystem, factor, cephcluster, doFullReconcile)
+	ok, err := o.controller.SetFilesystemReplication(rookVersion, cephVersion, o.config.CephFilesystem, factor, doFullReconcile)
 	if err != nil {
 		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "set filesystem %s replication to %d", o.config.CephFilesystem, factor))
 	}
 	didUpdate = didUpdate || ok
 
-	ok, err = o.controller.SetObjectStoreReplication(rookVersion, o.config.CephObjectStore, factor, cephcluster, doFullReconcile)
+	ok, err = o.controller.SetObjectStoreReplication(rookVersion, cephVersion, o.config.CephObjectStore, factor, doFullReconcile)
 	if err != nil {
 		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "set object store %s replication to %d", o.config.CephObjectStore, factor))
 	}
@@ -255,7 +262,7 @@ func (o *Operator) adjustPoolReplicationLevels(rookVersion semver.Version, numNo
 
 	// There is no CR to compare the desired and current level.
 	// Assume that if cephblockpool replication level has not yet been set then we need to do the same for device_health_metrics.
-	_, err = o.controller.SetDeviceHealthMetricsReplication(rookVersion, cephcluster.Status.CephVersion.Version, o.config.CephBlockPool, factor, cephcluster, doFullReconcile || didUpdate)
+	_, err = o.controller.SetDeviceHealthMetricsReplication(rookVersion, cephVersion, o.config.CephBlockPool, factor, doFullReconcile || didUpdate)
 	if err != nil {
 		multiErr = multierror.Append(multiErr, errors.Wrapf(err, "set device_health_metrics replication to %d", factor))
 	}

--- a/pkg/rook/cephcluster.go
+++ b/pkg/rook/cephcluster.go
@@ -1,0 +1,18 @@
+package rook
+
+import (
+	"errors"
+
+	"github.com/blang/semver"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+)
+
+// GetCephVersion returns the semver.Version of Ceph as reported by the cephv1.CephCluster
+// resource.
+func GetCephVersion(cluster cephv1.CephCluster) (semver.Version, error) {
+	if cluster.Status.CephVersion == nil {
+		return semver.Version{}, errors.New("status.CephVersion is nil")
+	}
+
+	return semver.Parse(cluster.Status.CephVersion.Version)
+}


### PR DESCRIPTION
Prior to ceph quincy, Rgw pools pg_num is set to 8, it is now 32:

```
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd pool get rook-ceph-store.rgw.buckets.index  pg_num
pg_num: 32
```

This is causing Rook to fail to reconcile the CephObjectStore resource with the following error:

```
2022-11-29 19:27:03.955317 E | ceph-object-controller: failed to reconcile CephObjectStore "rook-ceph/rook-ceph-store". failed to create object store deployments: failed to create object pools: failed to create metadata pools: failed to create pool "rook-ceph-store.rgw.buckets.index": failed to set size property to replicated pool "rook-ceph-store.rgw.buckets.index" to 3: failed to set pool property "size" on pool "rook-ceph-store.rgw.buckets.index": exit status 34
```

```
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd pool set rook-ceph-store.rgw.buckets.index size 3
Error ERANGE: pool id 8 pg_num 32 size 3 would mean 755 total pgs, which exceeds max 750 (mon_max_pg_per_osd 250 * num_in_osds 3)
command terminated with exit code 34
```

The root cause seems to be this warning which is preventing Rook for setting the pg_num_min:

```
2022-11-29 19:27:26.559787 W | ceph-object-controller: failed to adjust the PG count for rgw metadata pools. using the general default. failed to get config setting "rgw_rados_pool_pg_num_min" for user "mon.": exit status 2
```

```
$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config get mon.
WHO     MASK  LEVEL     OPTION                                 VALUE       RO
mon           advanced  auth_allow_insecure_global_id_reclaim  false
global        basic     log_to_file                            true
global        advanced  mon_allow_pool_delete                  true
global        advanced  mon_allow_pool_size_one                true
global        advanced  mon_cluster_log_file
global        advanced  mon_pg_warn_min_per_osd                0
global        basic     ms_client_mode                         crc secure  *
global        basic     ms_cluster_mode                        crc secure  *
global        advanced  ms_osd_compress_mode                   none
global        basic     ms_service_mode                        crc secure  *
ethan@ethanm-rook-12:~$ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph config get mon. rgw_rados_pool_pg_num_min
Error ENOENT: unrecognized key 'rgw_rados_pool_pg_num_min'
command terminated with exit code 2
```

It looks like this option has been removed in Ceph as of Quincy:

https://tracker.ceph.com/issues/54277
https://ceph.io/en/news/blog/2022/v17-2-1-quincy-released/

I've opened an issue. This change attempts to address the bug until it is fixed upstream.
https://github.com/rook/rook/issues/11366