### PR TITLE
Explicitly set replicas to 1

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -28,6 +28,7 @@ metadata:
   name: ekc-operator
   namespace: kurl
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: ekc-operator


### PR DESCRIPTION
If ekco deployment is scaled to 0 it will not scale back up if this is not explicitly set