### PR TITLE
Reconcile mon count fails on Rook 1.0.4, cephVersion empty

### DIFF
--- a/pkg/ekcoops/operator.go
+++ b/pkg/ekcoops/operator.go
@@ -158,15 +158,14 @@ func (o *Operator) reconcileRook(rookVersion semver.Version, nodes []corev1.Node
 			err := o.adjustPoolReplicationLevels(rookVersion, readyCount, doFullReconcile)
 			if err != nil {
 				multiErr = multierror.Append(multiErr, errors.Wrapf(err, "adjust pool replication levels"))
-			} else {
-				err := o.controller.ReconcileMonCount(context.TODO(), readyCount)
-				if err != nil {
-					multiErr = multierror.Append(multiErr, errors.Wrapf(err, "reconcile mon count"))
-				}
-				err = o.controller.ReconcileMgrCount(context.TODO(), rookVersion, readyCount)
-				if err != nil {
-					multiErr = multierror.Append(multiErr, errors.Wrapf(err, "reconcile mgr count"))
-				}
+			}
+			err = o.controller.ReconcileMonCount(context.TODO(), readyCount)
+			if err != nil {
+				multiErr = multierror.Append(multiErr, errors.Wrapf(err, "reconcile mon count"))
+			}
+			err = o.controller.ReconcileMgrCount(context.TODO(), rookVersion, readyCount)
+			if err != nil {
+				multiErr = multierror.Append(multiErr, errors.Wrapf(err, "reconcile mgr count"))
 			}
 		}
 	}

--- a/pkg/rook/cephcluster_test.go
+++ b/pkg/rook/cephcluster_test.go
@@ -1,0 +1,69 @@
+package rook
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+)
+
+func TestGetCephVersion(t *testing.T) {
+	type args struct {
+		cluster cephv1.CephCluster
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    semver.Version
+		wantErr bool
+	}{
+		{
+			name: "status",
+			args: args{
+				cluster: cephv1.CephCluster{
+					Spec: cephv1.ClusterSpec{
+						CephVersion: cephv1.CephVersionSpec{
+							Image: "ceph/ceph:v15.2.8-20201217",
+						},
+					},
+					Status: cephv1.ClusterStatus{
+						CephVersion: &cephv1.ClusterVersion{
+							Image:   "ceph/ceph:v15.2.8-20201217",
+							Version: "15.2.8-0",
+						},
+					},
+				},
+			},
+			want:    semver.MustParse("15.2.8-0"),
+			wantErr: false,
+		},
+		{
+			name: "no status",
+			args: args{
+				cluster: cephv1.CephCluster{
+					Spec: cephv1.ClusterSpec{
+						CephVersion: cephv1.CephVersionSpec{
+							Image: "kurlsh/ceph:v14.2.0-9065b09-20210625",
+						},
+					},
+					Status: cephv1.ClusterStatus{},
+				},
+			},
+			want:    semver.MustParse("14.2.0-0"),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetCephVersion(tt.args.cluster)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetCephVersion() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetCephVersion() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- status.cephVersion is nil for Rook 1.0.4, use spec.cephVersion.Image
- ReconcileMonCount and ReconcileMgrCount should not depend on success of adjustPoolReplicationLevels

```
2022-12-13T05:36:49.490Z	INFO	ekcoops/poll.go:32	Reconcile failed: 1 error occurred:
	* adjust pool replication levels: 1 error occurred:
	* get ceph version: status.CephVersion is nil
```