### PR TITLE
chore: fix dependabot that has not been checking gomod

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,15 +10,6 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "gomod"
-    directory: "/"
-    labels:
-      - "dependencies"
-      - "go"
-      - "type::chore"
-    schedule:
-      interval: "weekly"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,7 +11,7 @@ updates:
       interval: "weekly"
 
   - package-ecosystem: "gomod"
-    directory: "/kurlkinds"
+    directory: "/"
     labels:
       - "dependencies"
       - "go"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,24 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "dependencies"
+      - "go"
+      - "type::chore"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/kurlkinds"
+    labels:
+      - "dependencies"
+      - "go"
+      - "type::chore"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     labels:


### PR DESCRIPTION
## Description 
Ekco gomod has not been updated via the dependabot