### PR TITLE
Fix Encoding of kubeadm.k8s.io/v1beta2 ClusterStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ This method is very much out of sync and doesn't work.  The current best way to 
 modify the deployment to pull the docker container produced as part of development.
 
 Steps
-1. **make build-ttl.sh** - Build the docker container for the current developement environment and deploy it to ttl.sh
+1. **make build-ttl.sh** - Build the docker container for the current development environment and deploy it to ttl.sh
 2. Deploy a kurl cluster that includes ecko and any other requirements for testing.
 3. **kubectl edit -n kurl deployment/ekc-operator**
    1. Replace .spec.image with your ttl.sh image
-   2. Replace .spec.imagePullPolicy with "Always" 
+   2. Replace .spec.imagePullPolicy with "Always"
    3. **kubectl delete pod -l app=ekc-operator -n kurl** - Delete the pod in the deployment to pull the new image
 
 

--- a/pkg/cluster/purge_node.go
+++ b/pkg/cluster/purge_node.go
@@ -228,11 +228,12 @@ func (c *Controller) removeKubeadmEndpoint(ctx context.Context, name string) (st
 }
 
 type k8s121ClusterStatus struct {
-	metav1.TypeMeta
-	APIEndpoints map[string]k8s121APIEndpoint
+	Kind         string                       `yaml:"kind"`
+	APIVersion   string                       `yaml:"apiVersion"`
+	APIEndpoints map[string]k8s121APIEndpoint `yaml:"apiEndpoints"`
 }
 
 type k8s121APIEndpoint struct {
-	AdvertiseAddress string
-	BindPort         int32
+	AdvertiseAddress string `yaml:"advertiseAddress"`
+	BindPort         int32  `yaml:"bindPort"`
 }

--- a/pkg/cluster/purge_node_test.go
+++ b/pkg/cluster/purge_node_test.go
@@ -67,6 +67,51 @@ apiEndpoints:
 			},
 		},
 		{
+			name:     "when ClusterStatus field is incompatible then correct it on next update",
+			endpoint: "master-test-2", // removing master-test-2
+			clusterResources: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kubeadmconstants.KubeadmConfigConfigMap,
+						Namespace: metav1.NamespaceSystem,
+					},
+					TypeMeta: metav1.TypeMeta{},
+					Data: map[string]string{
+						clusterStatusConfigMapKey: `
+apiendpoints:
+  master-test-1:
+    advertiseAddress: 10.128.0.126
+    bindport: 6443
+  master-test-2:
+    advertiseaddress: 10.128.0.63
+    bindport: 6443
+typemeta:
+  kind: ClusterStatus
+  apiversion: kubeadm.k8s.io/v1beta2
+`,
+					},
+				},
+			},
+			expectedRemovedIP:    "10.128.0.63",
+			expectedRemainingIPs: []string{"10.128.0.126"},
+			expectedConfigMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubeadmconstants.KubeadmConfigConfigMap,
+					Namespace: metav1.NamespaceSystem,
+				},
+				TypeMeta: metav1.TypeMeta{},
+				Data: map[string]string{
+					clusterStatusConfigMapKey: `kind: ClusterStatus
+apiVersion: kubeadm.k8s.io/v1beta2
+apiEndpoints:
+  master-test-1:
+    advertiseAddress: 10.128.0.126
+    bindPort: 6443
+`,
+				},
+			},
+		},
+		{
 			name:     "when clusterStatus field does not exist then no updates to kubeadm configmap",
 			endpoint: "master-test-2", // removing master-test-2
 			clusterResources: []runtime.Object{
@@ -91,27 +136,29 @@ apiEndpoints:
 	}
 
 	for _, tt := range tests {
-		req := require.New(t)
-		logger, _ := zap.NewProduction()
-		client := clientsetfake.NewSimpleClientset(tt.clusterResources...)
-		c := NewController(ControllerConfig{
-			Client: client,
-		}, logger.Sugar())
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+			logger, _ := zap.NewProduction()
+			client := clientsetfake.NewSimpleClientset(tt.clusterResources...)
+			c := NewController(ControllerConfig{
+				Client: client,
+			}, logger.Sugar())
 
-		ip, remainingIPS, err := c.removeKubeadmEndpoint(context.Background(), tt.endpoint)
-		if err != nil {
-			if tt.wantErr {
-				req.Error(err)
-			} else {
-				req.NoError(err)
+			ip, remainingIPS, err := c.removeKubeadmEndpoint(context.Background(), tt.endpoint)
+			if err != nil {
+				if tt.wantErr {
+					req.Error(err)
+				} else {
+					req.NoError(err)
+				}
 			}
-		}
 
-		// kubeadm-config configmap gets updated when removing endpoints for k8s < 1.22
-		actualKubeadmConfigMap, _ := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).
-			Get(context.Background(), kubeadmconstants.KubeadmConfigConfigMap, metav1.GetOptions{})
-		req.Equal(tt.expectedRemovedIP, ip)
-		req.Equal(tt.expectedRemainingIPs, remainingIPS)
-		req.EqualValues(tt.expectedConfigMap, *actualKubeadmConfigMap)
+			// kubeadm-config configmap gets updated when removing endpoints for k8s < 1.22
+			actualKubeadmConfigMap, _ := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).
+				Get(context.Background(), kubeadmconstants.KubeadmConfigConfigMap, metav1.GetOptions{})
+			req.Equal(tt.expectedRemovedIP, ip)
+			req.Equal(tt.expectedRemainingIPs, remainingIPS)
+			req.EqualValues(tt.expectedConfigMap, *actualKubeadmConfigMap)
+		})
 	}
 }

--- a/pkg/cluster/purge_node_test.go
+++ b/pkg/cluster/purge_node_test.go
@@ -1,0 +1,117 @@
+package cluster
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientsetfake "k8s.io/client-go/kubernetes/fake"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+)
+
+func Test_removeKubeadmEndpoint(t *testing.T) {
+	tests := []struct {
+		name                 string
+		endpoint             string
+		clusterResources     []runtime.Object
+		expectedRemovedIP    string
+		expectedRemainingIPs []string
+		expectedConfigMap    corev1.ConfigMap
+		wantErr              bool
+	}{
+		{
+			name:     "when endpoint is removed expect kubeadm configmap to be mutated",
+			endpoint: "master-test-2", // removing master-test-2
+			clusterResources: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kubeadmconstants.KubeadmConfigConfigMap,
+						Namespace: metav1.NamespaceSystem,
+					},
+					TypeMeta: metav1.TypeMeta{},
+					Data: map[string]string{
+						clusterStatusConfigMapKey: `kind: ClusterStatus
+apiVersion: kubeadm.k8s.io/v1beta2
+apiEndpoints:
+  master-test-1:
+    advertiseAddress: 10.128.0.126
+    bindPort: 6443
+  master-test-2:
+    advertiseAddress: 10.128.0.63
+    bindPort: 6443
+`,
+					},
+				},
+			},
+			expectedRemovedIP:    "10.128.0.63",
+			expectedRemainingIPs: []string{"10.128.0.126"},
+			expectedConfigMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubeadmconstants.KubeadmConfigConfigMap,
+					Namespace: metav1.NamespaceSystem,
+				},
+				TypeMeta: metav1.TypeMeta{},
+				Data: map[string]string{
+					clusterStatusConfigMapKey: `kind: ClusterStatus
+apiVersion: kubeadm.k8s.io/v1beta2
+apiEndpoints:
+  master-test-1:
+    advertiseAddress: 10.128.0.126
+    bindPort: 6443
+`,
+				},
+			},
+		},
+		{
+			name:     "when clusterStatus field does not exist then no updates to kubeadm configmap",
+			endpoint: "master-test-2", // removing master-test-2
+			clusterResources: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kubeadmconstants.KubeadmConfigConfigMap,
+						Namespace: metav1.NamespaceSystem,
+					},
+					TypeMeta: metav1.TypeMeta{},
+					Data:     map[string]string{},
+				},
+			},
+			expectedConfigMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubeadmconstants.KubeadmConfigConfigMap,
+					Namespace: metav1.NamespaceSystem,
+				},
+				TypeMeta: metav1.TypeMeta{},
+				Data:     map[string]string{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		req := require.New(t)
+		logger, _ := zap.NewProduction()
+		client := clientsetfake.NewSimpleClientset(tt.clusterResources...)
+		c := NewController(ControllerConfig{
+			Client: client,
+		}, logger.Sugar())
+
+		ip, remainingIPS, err := c.removeKubeadmEndpoint(context.Background(), tt.endpoint)
+		if err != nil {
+			if tt.wantErr {
+				req.Error(err)
+			} else {
+				req.NoError(err)
+			}
+		}
+
+		// kubeadm-config configmap gets updated when removing endpoints for k8s < 1.22
+		actualKubeadmConfigMap, _ := client.CoreV1().ConfigMaps(metav1.NamespaceSystem).
+			Get(context.Background(), kubeadmconstants.KubeadmConfigConfigMap, metav1.GetOptions{})
+		req.Equal(tt.expectedRemovedIP, ip)
+		req.Equal(tt.expectedRemainingIPs, remainingIPS)
+		req.EqualValues(tt.expectedConfigMap, *actualKubeadmConfigMap)
+	}
+}

--- a/pkg/cluster/purge_node_test.go
+++ b/pkg/cluster/purge_node_test.go
@@ -133,6 +133,52 @@ apiEndpoints:
 				Data:     map[string]string{},
 			},
 		},
+		{
+			name: "when ClusterStatus is malformed then correct it as a no-op update (side effect)",
+			clusterResources: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      kubeadmconstants.KubeadmConfigConfigMap,
+						Namespace: metav1.NamespaceSystem,
+					},
+					TypeMeta: metav1.TypeMeta{},
+					Data: map[string]string{
+						clusterStatusConfigMapKey: `
+apiendpoints:
+  master-test-1:
+    advertiseaddress: 10.128.0.126
+    bindport: 6443
+  master-test-2:
+    advertiseaddress: 10.128.0.63
+    bindport: 6443
+typemeta:
+  kind: ClusterStatus
+  apiversion: kubeadm.k8s.io/v1beta2
+`,
+					},
+				},
+			},
+			expectedRemainingIPs: []string{"10.128.0.126", "10.128.0.63"},
+			expectedConfigMap: corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      kubeadmconstants.KubeadmConfigConfigMap,
+					Namespace: metav1.NamespaceSystem,
+				},
+				TypeMeta: metav1.TypeMeta{},
+				Data: map[string]string{
+					clusterStatusConfigMapKey: `kind: ClusterStatus
+apiVersion: kubeadm.k8s.io/v1beta2
+apiEndpoints:
+  master-test-1:
+    advertiseAddress: 10.128.0.126
+    bindPort: 6443
+  master-test-2:
+    advertiseAddress: 10.128.0.63
+    bindPort: 6443
+`,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fix a bug where the script [`ekco-purge-node.sh`](https://github.com/replicatedhq/kURL/blob/main/addons/ekco/template/base/ekco-purge-node.sh) was serializing a malformed kubeadm.k8s.io/v1beta2 ClusterStatus.

Before the fix, `ekco-purge-node.sh` wrote the following ClusterStatus YAML in `kubeadm-config` configmap:
```yaml
apiendpoints:
  rafael-kurl-ecko-purge-master:
    advertiseaddress: 10.128.0.126
    bindport: 6443
  rafael-kurl-ecko-purge-master-2:
    advertiseaddress: 10.128.0.63
    bindport: 6443
typemeta:
  apiversion: kubeadm.k8s.io/v1beta2
  kind: ClusterStatus
```
_Note ^ that all the keys are lowercase and the addition of a `typemeta` object._

With this fix, `ekco-purge-node.sh` now writes the correct YAML:
```yaml
apiEndpoints:
  rafael-kurl-ecko-purge-master:
    advertiseAddress: 10.128.0.126
    bindPort: 6443
  rafael-kurl-ecko-purge-master-2:
    advertiseAddress: 10.128.0.63
    bindPort: 6443
apiVersion: kubeadm.k8s.io/v1beta2
kind: ClusterStatus
``` 

Also fixed a null pointer dereference: https://github.com/replicatedhq/ekco/compare/rafaelpolanco/sc-68799/ekco-purge-node-botches-clusterstatus-type?expand=1#diff-ad81a0609056246ca9c3a49c3fee9b8e3ffa9526709e717d77e8347cfe81e9c1R107-R115