### PR TITLE
bug: does not attempt to migrate minio if its namespace is empty

### DIFF
--- a/pkg/objectstore/minio.go
+++ b/pkg/objectstore/minio.go
@@ -10,6 +10,9 @@ import (
 )
 
 func IsMinioInUse(ctx context.Context, client kubernetes.Interface, namespace string) (bool, error) {
+	if namespace == "" {
+		return false, nil
+	}
 	// if the minio NS does not exist, it is not in use
 	_, err := client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
If ekco is running in a cluster that does not have Minio installed the storage migration fails with the following log:

```
checking if the cluster is ready to migrate
starting object storage migration
failed to migrate object storage: check if minio is in use: get minio namespace : resource name may not be empty
```