### PR TITLE
feat: migration ready endpoint returns the number of nodes

### DIFF
--- a/pkg/migrate/storage.go
+++ b/pkg/migrate/storage.go
@@ -100,7 +100,7 @@ type MigrationReadyResult struct {
 	NrNodes int    `json:"nrNodes"`
 }
 
-// IsMigrationReady returns if the cluster is ready to migrate storage.This is true if Ceph is setup/healthy, the ceph storageclass is
+// IsMigrationReady returns if the cluster is ready to migrate storage. This is true if Ceph is setup/healthy, the ceph storageclass is
 // present in the cluster, and the ceph object store user exists. This function also returns the current of number of nodes in the cluster.
 func IsMigrationReady(ctx context.Context, config ekcoops.Config, controllers types.ControllerConfig) (*MigrationReadyResult, error) {
 	nodes, err := controllers.Client.CoreV1().Nodes().List(ctx, v1.ListOptions{})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,7 +32,7 @@ func Serve(ctx context.Context, config ekcoops.Config, client *cluster.Controlle
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			if _, err := w.Write([]byte(err.Error())); err != nil {
-				log.Printf("marshaling json: %v", err)
+				log.Printf("write json marshaling error: %v", err)
 			}
 			return
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 
@@ -18,7 +19,7 @@ func Serve(ctx context.Context, config ekcoops.Config, client *cluster.Controlle
 	})
 
 	mux.HandleFunc("/storagemigration/ready", func(w http.ResponseWriter, r *http.Request) {
-		_, message, err := migrate.IsMigrationReady(r.Context(), config, client.Config)
+		status, err := migrate.IsMigrationReady(r.Context(), config, client.Config)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			_, err := w.Write([]byte(err.Error()))
@@ -27,10 +28,16 @@ func Serve(ctx context.Context, config ekcoops.Config, client *cluster.Controlle
 			}
 			return
 		}
-
-		w.WriteHeader(http.StatusOK)
-		_, err = w.Write([]byte(message))
+		data, err := json.Marshal(status)
 		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			if _, err := w.Write([]byte(err.Error())); err != nil {
+				log.Printf("marshaling json: %v", err)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err = w.Write(data); err != nil {
 			log.Printf("write ready status: %v", err)
 		}
 	})


### PR DESCRIPTION
To enable the join.sh script to determine the appropriate timing for approving a storage migration, it requires information about the current number of nodes in the cluster. By comparing this value with its own expected count, the script can initiate a migration if they are equal. This pull request introduces a modification to the migration ready endpoint, enabling it to respond with the current number of nodes in the cluster.