### PR TITLE
if object store user is not yet found wait for it

### DIFF
--- a/pkg/migrate/storage.go
+++ b/pkg/migrate/storage.go
@@ -144,7 +144,7 @@ func IsMigrationReady(ctx context.Context, config ekcoops.Config, controllers ty
 	_, err = controllers.Client.CoreV1().Secrets(cluster.RookCephNS).Get(ctx, "rook-ceph-object-user-rook-ceph-store-kurl", v1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("ceph object store secret not found")
+			return &MigrationReadyResult{Reason: "ceph object store secret not found", Ready: false}, nil
 		}
 		return nil, fmt.Errorf("get ceph object store secret: %w", err)
 	}


### PR DESCRIPTION
```
2023-07-25 19:46:32+00:00 2023/07/25 19:46:32 cluster reporting ready for migration: ceph cluster was Progressing, not ready
2023-07-25 19:46:37+00:00 Error: failed to wait for ekco to be ready for migration: failed to get ekco status (500): ceph object store secret not found
2023-07-25 19:46:37+00:00 Failed to migrate from OpenEBS to Rook. The installation will move on.
```