### PR TITLE
chore: Do not reconcile CephCluster spec if managed by Helm

### DIFF
--- a/pkg/rook/cephcluster.go
+++ b/pkg/rook/cephcluster.go
@@ -24,3 +24,16 @@ func GetCephVersion(cluster cephv1.CephCluster) (semver.Version, error) {
 
 	return semver.Parse(cluster.Status.CephVersion.Version)
 }
+
+// CephClusterManagedByHelm returns true if the CephCluster spec was applied by Helm
+func CephClusterManagedByHelm(cluster cephv1.CephCluster) bool {
+	labels := cluster.Labels
+
+	managedBy, ok := labels["app.kubernetes.io/managed-by"]
+	if ok {
+		if strings.ToLower(managedBy) == "helm" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
When the Ceph Cluster is created via `helm.InstallChartArchive()` when `rookMinimumNodeCount` >= 3, no modifications should be made to the `CephCluster` CR. Namely for two reasons, 1) CephCluster spec in the cluster should not deviate from what was configured in the chart 2) modifying the CR delays the Rook reconciliation process