### PR TITLE
fix: specify imageFormat and imageFeatures values for CephBlockPool Storage Class

### DIFF
--- a/pkg/helm/rookcephcluster/values.yaml
+++ b/pkg/helm/rookcephcluster/values.yaml
@@ -138,6 +138,15 @@ cephBlockPools:
       name: distributed
       isDefault: false
       parameters:
+         # RBD image format. Defaults to "2".
+        imageFormat: "2"
+
+        # RBD image features, equivalent to OR'd bitfield value: 63
+        # Available for imageFormat: "2". Older releases of CSI RBD
+        # support only the `layering` feature. The Linux kernel (KRBD) supports the
+        # full feature complement as of 5.4
+        imageFeatures: layering
+
         # These secrets contain Ceph admin credentials.
         csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
         csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
OpenEBS to Rook storage migration [test](https://testgrid.kurl.sh/run/rafael-rook-to-openebs-migraton-tests-20230810235054) was failing on AmazonLinux, CentOS7 and Oracle Linux 7:
<img width="2095" alt="image" src="https://github.com/replicatedhq/ekco/assets/6497491/d359971b-ccdb-4144-8e6a-fb8c74c550df">

The migration tried to create a pod and mount a Rook RBD volume using the `distributed` storage class but the mount failed:

```sh
[rafael@rafael-local-dist-storage-centos79-1b ~]$ kubectl describe pod migrate-kotsadm-rqlite-kotsadm-rqlite-2
Name:             migrate-kotsadm-rqlite-kotsadm-rqlite-2
Namespace:        default
Priority:         0
Service Account:  default
Node:             rafael-local-dist-storage-centos79-1c/10.128.0.98
Start Time:       Tue, 08 Aug 2023 22:57:24 +0000
Labels:           kurl.sh/pvcmigrate=kotsadm-rqlite-kotsadm-rqlite-2
Annotations:      <none>
Status:           Pending
IP:               
IPs:              <none>
Containers:
  pvmigrate:
    Container ID:  
    Image:         replicated/kurl-util:v2023.08.07-0
    Image ID:      
    Port:          <none>
    Host Port:     <none>
    Command:
      rsync
    Args:
      -a
      -v
      -P
      --delete
      /source/
      /dest
    State:          Waiting
      Reason:       ContainerCreating
    Ready:          False
    Restart Count:  0
    Environment:    <none>
    Mounts:
      /dest from dest (rw)
      /source from source (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-mkrwv (ro)
Conditions:
  Type              Status
  Initialized       True 
  Ready             False 
  ContainersReady   False 
  PodScheduled      True 
Volumes:
  source:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  kotsadm-rqlite-kotsadm-rqlite-2
    ReadOnly:   false
  dest:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  kotsadm-rqlite-kotsadm-rqlite-2-pvcmigrate
    ReadOnly:   false
  kube-api-access-mkrwv:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason                  Age                From                     Message
  ----     ------                  ----               ----                     -------
  Normal   Scheduled               58s                default-scheduler        Successfully assigned default/migrate-kotsadm-rqlite-kotsadm-rqlite-2 to rafael-local-dist-storage-centos79-1c
  Normal   SuccessfulAttachVolume  58s                attachdetach-controller  AttachVolume.Attach succeeded for volume "pvc-6c8bcd13-daea-421e-9b0d-87ab62830e84"
  Warning  FailedMount             24s (x7 over 56s)  kubelet                  MountVolume.MountDevice failed for volume "pvc-6c8bcd13-daea-421e-9b0d-87ab62830e84" : rpc error: code = Internal desc = unsupported krbd Feature
```

Inspecting further, the `csi-rbdplugin` logs showed:
```
[rafael@rafael-local-dist-storage-centos79-1b ~]$ kubectl logs -l app=csi-rbdplugin -n rook-ceph -c csi-rbdplugin
W0808 22:50:46.177318    2000 rbd_attach.go:226] nbd modprobe failed (an error (exit status 1) occurred while running modprobe args: [nbd]): "modprobe: FATAL: Module nbd not found in directory /lib/modules/3.10.0-1160.6.1.el7.x86_64\n"
W0808 22:50:46.177376    2000 driver.go:194] EnableGRPCMetrics is deprecated
E0808 22:59:35.827211   15838 utils.go:210] ID: 38 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 GRPC error: rpc error: code = Internal desc = unsupported krbd Feature
E0808 23:01:37.903142   15838 rbd_util.go:359] ID: 42 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 krbd feature "object-map" not supported
E0808 23:01:37.903187   15838 nodeserver.go:242] ID: 42 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 unsupported krbd Feature, set `tryOtherMounters:true` or fix krbd driver
E0808 23:01:37.903270   15838 utils.go:210] ID: 42 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 GRPC error: rpc error: code = Internal desc = unsupported krbd Feature
E0808 23:03:39.977189   15838 rbd_util.go:359] ID: 46 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 krbd feature "fast-diff" not supported
E0808 23:03:39.977226   15838 nodeserver.go:242] ID: 46 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 unsupported krbd Feature, set `tryOtherMounters:true` or fix krbd driver
E0808 23:03:39.977304   15838 utils.go:210] ID: 46 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 GRPC error: rpc error: code = Internal desc = unsupported krbd Feature
E0808 23:05:42.086926   15838 rbd_util.go:359] ID: 50 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 krbd feature "object-map" not supported
E0808 23:05:42.086961   15838 nodeserver.go:242] ID: 50 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 unsupported krbd Feature, set `tryOtherMounters:true` or fix krbd driver
E0808 23:05:42.087033   15838 utils.go:210] ID: 50 Req-ID: 0001-0009-rook-ceph-0000000000000004-01d9aae0-a5db-4d83-a425-3abd20c0fd71 GRPC error: rpc error: code = Internal desc = unsupported krbd Feature
W0808 22:50:42.774817    4240 rbd_attach.go:226] nbd modprobe failed (an error (exit status 1) occurred while running modprobe args: [nbd]): "modprobe: FATAL: Module nbd not found in directory /lib/modules/3.10.0-1160.6.1.el7.x86_64\n"
W0808 22:50:42.774885    4240 driver.go:194] EnableGRPCMetrics is deprecated
```

The PV used by the pod showed that the RBD volume attributes `imageFormat` and `imageFeatures` were not set:
```sh
[rafael@rafael-local-dist-storage-centos79-1a ~]$ kubectl describe pv pvc-163b71dc-1b64-4dab-87bc-65b1654971e8
Name:            pvc-163b71dc-1b64-4dab-87bc-65b1654971e8
Labels:          <none>
Annotations:     pv.kubernetes.io/provisioned-by: rook-ceph.rbd.csi.ceph.com
                 volume.kubernetes.io/provisioner-deletion-secret-name: rook-csi-rbd-provisioner
                 volume.kubernetes.io/provisioner-deletion-secret-namespace: rook-ceph
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    distributed
Status:          Bound
Claim:           default/migration-test
Reclaim Policy:  Delete
Access Modes:    RWO
VolumeMode:      Filesystem
Capacity:        1Gi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            rook-ceph.rbd.csi.ceph.com
    FSType:            ext4
    VolumeHandle:      0001-0009-rook-ceph-0000000000000004-b2fdf527-1a58-405c-99bd-6a6f525d05f6
    ReadOnly:          false
    VolumeAttributes:      clusterID=rook-ceph
                           imageName=csi-vol-b2fdf527-1a58-405c-99bd-6a6f525d05f6
                           journalPool=replicapool
                           pool=replicapool
                           storage.kubernetes.io/csiProvisionerIdentity=1691535044889-8081-rook-ceph.rbd.csi.ceph.com
Events:                <none>
```

This PR will add `imageFeatures=layering` and `imageFormat=2` to `values.yaml` so that a correct RBD storage class yaml is rendered and therefore fix volume mounting on Amazon-Linux2.0/CentOS7/OL7 operating systems.

Ref: [sc-82282]