### PR TITLE
bug: diable haproxy zero copy forwarding

### DIFF
--- a/pkg/internallb/haproxy.cfg
+++ b/pkg/internallb/haproxy.cfg
@@ -4,6 +4,7 @@
 #---------------------------------------------------------------------
 global
     log stdout format raw local0 notice
+    tune.disable-zero-copy-forwarding
     daemon
 
 #---------------------------------------------------------------------

--- a/pkg/internallb/haproxy_test.go
+++ b/pkg/internallb/haproxy_test.go
@@ -27,6 +27,7 @@ func TestGenerateHAProxyConfig(t *testing.T) {
 #---------------------------------------------------------------------
 global
     log stdout format raw local0 notice
+    tune.disable-zero-copy-forwarding
     daemon
 
 #---------------------------------------------------------------------


### PR DESCRIPTION
haproxy version 2.9.1 is consuming > 100% of cpu. the problem does not happen in older versions. this commit disables the zero copy forwarding as per workaround here:

https://github.com/haproxy/haproxy/issues/2402#issuecomment-1875104101

we may want to enable this back in once it is fixed upstream.