### PR TITLE
not having an expected cert present to rotate is a nonfatal error

### DIFF
--- a/pkg/rotate/rotate.go
+++ b/pkg/rotate/rotate.go
@@ -37,7 +37,8 @@ func RotateCerts(ttl time.Duration, hostname string) error {
 		if ok, err := rm.CertificateExists(handler.Name); err != nil {
 			return errors.Wrapf(err, "check for existing %s on host %s", handler.Name, hostname)
 		} else if !ok {
-			return fmt.Errorf("Missing certificate %s on %s", handler.Name, hostname)
+			fmt.Printf("Missing certificate %s on host %s\n", handler.Name, hostname)
+			continue
 		}
 
 		ei, err := rm.GetCertificateExpirationInfo(handler.Name)


### PR DESCRIPTION
> root@rotate-certs-test:/etc/kubernetes# ekco rotate-certs --ttl=720h0m0s
admin.conf has 364d until expiration on host laverya-kurl, skipping renewal
apiserver has 364d until expiration on host laverya-kurl, skipping renewal
apiserver-etcd-client has 364d until expiration on host laverya-kurl, skipping renewal
apiserver-kubelet-client has 364d until expiration on host laverya-kurl, skipping renewal
controller-manager.conf has 364d until expiration on host laverya-kurl, skipping renewal
etcd-healthcheck-client has 364d until expiration on host laverya-kurl, skipping renewal
etcd-peer has 364d until expiration on host laverya-kurl, skipping renewal
etcd-server has 364d until expiration on host laverya-kurl, skipping renewal
front-proxy-client has 364d until expiration on host laverya-kurl, skipping renewal
scheduler.conf has 364d until expiration on host laverya-kurl, skipping renewal
Error: Missing certificate super-admin.conf on laverya-kurl

There is a new cert file, super-admin.conf in latest kubeadm - but not in old versions, and so this rotate command will otherwise fail on those k8s versions.