### PR TITLE
feat(ci): add release Slack notifications

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,3 +20,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - run: make docker-image DOCKER_IMAGE=replicated/ekco:$GITHUB_REF_NAME VERSION=$GITHUB_REF_NAME
       - run: docker push replicated/ekco:$GITHUB_REF_NAME
+
+  notify:
+    needs: release
+    uses: replicatedhq/reusable-workflows/.github/workflows/notify-release.yml@main
+    with:
+      tag: ${{ github.ref_name }}
+    secrets:
+      slack_webhook: ${{ secrets.PRODUCTION_SYSTEMS_SLACK_WEBHOOK }}


### PR DESCRIPTION
# feat(ci): add release Slack notifications

## Summary
This PR adds a `notify` job to the release workflow that automatically sends a Slack notification via a reusable workflow whenever a new EKCO release is published.

## Changes
- Added `notify` job to `.github/workflows/release.yaml`
- Job depends on the `release` job completing successfully
- Uses `replicatedhq/reusable-workflows/.github/workflows/notify-release/notify-release.yml@main`
- Passes the release tag and `PRODUCTION_SYSTEMS_SLACK_WEBHOOK` secret

## UAT
1. Merge this PR
2. Create and push a new semver tag (e.g., `v0.1.0`)
3. Verify the release workflow runs successfully
4. Confirm a Slack notification is sent to the configured channel with the release tag
