### PR TITLE
fix: validate kubelet-serving CSRs before auto-approval

### DIFF
--- a/docs/testing-kubelet-csr-rotation.md
+++ b/docs/testing-kubelet-csr-rotation.md
@@ -1,0 +1,171 @@
+# Testing EKCO kubelet-serving CSR approval
+
+This guide exercises `reconcileCertificateSigningRequests` in a real kURL cluster by forcing a kubelet serving certificate rotation. It is useful for validating both the fix for [GHSA-x7j5-fww5-mqmv](https://github.com/replicatedhq/ekco/security/advisories/GHSA-x7j5-fww5-mqmv) and the regression test in `pkg/ekcoops/csr_test.go`.
+
+## What this tests
+
+- EKCO sees a new `kubernetes.io/kubelet-serving` CSR.
+- The operator’s approval logic runs against an authenticated, real-world request from a kubelet.
+- A valid CSR from the node itself is approved and the kubelet gets a new serving certificate.
+- After the fix, malicious CSRs (wrong requester, foreign SANs, etc.) are rejected.
+
+## Prerequisites
+
+- A kURL cluster with EKCO running (`kubectl get pods -n kurl -l app=ekc-operator`).
+- `kubectl` access to the cluster.
+- `ssh` or shell access to a worker node.
+- A maintenance window where brief `kubectl logs` / `kubectl exec` disruption to one worker is acceptable.
+
+## Procedure
+
+### 1. Pick a worker node
+
+Do **not** run this on a control-plane node first. Choose a worker node and record its name.
+
+```bash
+export NODE_NAME=worker-1
+```
+
+### 2. Optional: drain the node
+
+```bash
+kubectl drain "$NODE_NAME" --ignore-daemonsets --delete-emptydir-data
+```
+
+### 3. Remove the kubelet serving certificate on the node
+
+SSH to the node and delete the kubelet serving certificate/key. The kubelet will recreate them on restart and submit a new CSR.
+
+```bash
+ssh "$NODE_NAME" sudo bash -c '
+  ls -la /var/lib/kubelet/pki/kubelet-server*
+  rm -f /var/lib/kubelet/pki/kubelet-server-*.pem
+  rm -f /var/lib/kubelet/pki/kubelet-server-current.pem
+'
+```
+
+### 4. Restart kubelet
+
+```bash
+ssh "$NODE_NAME" sudo systemctl restart kubelet
+```
+
+If kubelet runs as a container, restart the container instead:
+
+```bash
+ssh "$NODE_NAME" sudo bash -c '
+  KUBELET_PID=$(pgrep -x kubelet)
+  kill -SIGHUP "$KUBELET_PID"
+'
+```
+
+### 5. Watch for a new CSR
+
+From a control-plane node or your workstation:
+
+```bash
+kubectl get csr -w
+```
+
+Expect a CSR that looks like:
+
+```text
+NAME        AGE   SIGNERNAME                        REQUESTOR              STATUS
+worker-1... 0s    kubernetes.io/kubelet-serving     system:node:worker-1   Pending
+```
+
+The `REQUESTOR` must be `system:node:<node-name>` and the `SIGNERNAME` must be `kubernetes.io/kubelet-serving`.
+
+### 6. Watch EKCO approve the CSR
+
+```bash
+kubectl logs -n kurl deployment/ekc-operator -f
+```
+
+With the current vulnerable code you will see:
+
+```text
+CSR approval is successful <csr-name>
+```
+
+After the fix, the same message should appear only for a valid CSR that passes the new validation checks.
+
+### 7. Verify the kubelet serving certificate was renewed
+
+Back on the worker node:
+
+```bash
+ssh "$NODE_NAME" sudo bash -c '
+  ls -la /var/lib/kubelet/pki/kubelet-server*
+  openssl x509 -in /var/lib/kubelet/pki/kubelet-server-current.pem -text -noout | head -20
+'
+```
+
+You should see a new certificate issued by the cluster CA, with SANs matching the node’s addresses.
+
+### 8. Verify `kubectl logs`/`exec` work
+
+```bash
+kubectl run -it --rm debug --image=alpine --overrides='{"spec":{"nodeName":"'$NODE_NAME'"}}' --restart=Never -- sh
+```
+
+Inside the pod, run `hostname` and then exit. The command should succeed, which proves the kubelet serving cert is trusted by the API server.
+
+### 9. Uncordon the node
+
+```bash
+kubectl uncordon "$NODE_NAME"
+```
+
+## What can go wrong
+
+- If EKCO is disabled or the add-on does not grant `approve` on the `kubernetes.io/kubelet-serving` signer, the CSR stays `Pending` and kubelet logs errors. Check EKCO RBAC and the `auto_approve_kubelet_csrs` configuration.
+- If the kubelet does not restart cleanly, the node may become `NotReady`. Use `journalctl -u kubelet -f` on the node to debug.
+- If you test on a control-plane node and the kubelet serving cert is not approved quickly, `kubectl logs`/`exec` to pods on that node can break until the cert is restored.
+
+## Testing rejection of malicious CSRs
+
+To verify the fix rejects attacker-shaped CSRs, create a test CSR manually and submit it:
+
+```bash
+openssl req -new -newkey rsa:2048 -nodes \
+  -subj "/O=system:nodes/CN=system:node:worker-1" \
+  -addext "subjectAltName = DNS:kubernetes,DNS:kubernetes.default,IP:10.96.0.1" \
+  -keyout /tmp/test.key -out /tmp/test.csr
+
+CSR_B64=$(base64 -w 0 /tmp/test.csr)
+
+cat <<EOF | kubectl apply -f -
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: test-attack-csr
+spec:
+  signerName: kubernetes.io/kubelet-serving
+  request: ${CSR_B64}
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  username: system:serviceaccount:default:pwn
+EOF
+```
+
+Then watch:
+
+```bash
+kubectl get csr test-attack-csr -w
+```
+
+After the fix, this CSR should remain `Pending` and EKCO should not log an approval. Clean it up when done:
+
+```bash
+kubectl delete csr test-attack-csr
+```
+
+## Related code
+
+- `pkg/ekcoops/operator.go` — `reconcileCertificateSigningRequests`
+- `pkg/ekcoops/csr_test.go` — unit/regression tests
+- `../kURL/addons/ekco/template/base/configmap.tmpl.yaml` — add-on setting `auto_approve_kubelet_csrs: true`
+- `../kURL/addons/ekco/template/base/rbac.yaml` — signer approval RBAC

--- a/docs/testing-kubelet-csr-rotation.md
+++ b/docs/testing-kubelet-csr-rotation.md
@@ -32,19 +32,29 @@ export NODE_NAME=worker-1
 kubectl drain "$NODE_NAME" --ignore-daemonsets --delete-emptydir-data
 ```
 
-### 3. Remove the kubelet serving certificate on the node
+### 3. Check whether kubelet serving cert rotation is enabled
 
-SSH to the node and delete the kubelet serving certificate/key. The kubelet will recreate them on restart and submit a new CSR.
+SSH to the node and list the kubelet PKI directory:
+
+```bash
+ssh "$NODE_NAME" sudo ls -la /var/lib/kubelet/pki
+```
+
+If you see `kubelet-server-*.pem` and `kubelet-server-current.pem`, serving cert rotation is enabled — skip to step 6.
+
+If you only see client certificates (`kubelet-client-*.pem`, `kubelet-client-current.pem`) and a self-signed `kubelet.crt`/`kubelet.key`, serving cert rotation is **not enabled**. You must enable it before this test can exercise the CSR approval path.
+
+### 4. Enable kubelet serving cert rotation (if needed)
+
+Add `serverTLSBootstrap: true` to the kubelet KubeletConfiguration file. The standard path is `/var/lib/kubelet/config.yaml`.
 
 ```bash
 ssh "$NODE_NAME" sudo bash -c '
-  ls -la /var/lib/kubelet/pki/kubelet-server*
-  rm -f /var/lib/kubelet/pki/kubelet-server-*.pem
-  rm -f /var/lib/kubelet/pki/kubelet-server-current.pem
+  grep -q "serverTLSBootstrap: true" /var/lib/kubelet/config.yaml || echo "serverTLSBootstrap: true" >> /var/lib/kubelet/config.yaml
 '
 ```
 
-### 4. Restart kubelet
+Then restart kubelet:
 
 ```bash
 ssh "$NODE_NAME" sudo systemctl restart kubelet
@@ -59,7 +69,36 @@ ssh "$NODE_NAME" sudo bash -c '
 '
 ```
 
-### 5. Watch for a new CSR
+After restart, the kubelet will create a `kubernetes.io/kubelet-serving` CSR. Verify it appears:
+
+```bash
+kubectl get csr -w
+```
+
+You should see a pending CSR like:
+
+```text
+NAME        AGE   SIGNERNAME                        REQUESTOR              STATUS
+worker-1... 0s    kubernetes.io/kubelet-serving     system:node:worker-1   Pending
+```
+
+At this point the initial serving cert is already being requested, so you do not need to delete it. Watch EKCO approve it in step 7, then come back to step 5 if you want to force a second rotation.
+
+### 5. Remove the kubelet serving certificate to force a second rotation
+
+Once serving cert rotation is enabled, you can delete the serving cert/key on the node. The kubelet will recreate them on restart and submit a new CSR.
+
+```bash
+ssh "$NODE_NAME" sudo bash -c '
+  ls -la /var/lib/kubelet/pki/kubelet-server*
+  rm -f /var/lib/kubelet/pki/kubelet-server-*.pem
+  rm -f /var/lib/kubelet/pki/kubelet-server-current.pem
+'
+```
+
+Then restart kubelet as shown in step 4.
+
+### 6. Watch for a new CSR
 
 From a control-plane node or your workstation:
 
@@ -76,7 +115,7 @@ worker-1... 0s    kubernetes.io/kubelet-serving     system:node:worker-1   Pendi
 
 The `REQUESTOR` must be `system:node:<node-name>` and the `SIGNERNAME` must be `kubernetes.io/kubelet-serving`.
 
-### 6. Watch EKCO approve the CSR
+### 7. Watch EKCO approve the CSR
 
 ```bash
 kubectl logs -n kurl deployment/ekc-operator -f
@@ -90,7 +129,7 @@ CSR approval is successful <csr-name>
 
 After the fix, the same message should appear only for a valid CSR that passes the new validation checks.
 
-### 7. Verify the kubelet serving certificate was renewed
+### 8. Verify the kubelet serving certificate was renewed
 
 Back on the worker node:
 
@@ -103,7 +142,7 @@ ssh "$NODE_NAME" sudo bash -c '
 
 You should see a new certificate issued by the cluster CA, with SANs matching the node’s addresses.
 
-### 8. Verify `kubectl logs`/`exec` work
+### 9. Verify `kubectl logs`/`exec` work
 
 ```bash
 kubectl run -it --rm debug --image=alpine --overrides='{"spec":{"nodeName":"'$NODE_NAME'"}}' --restart=Never -- sh
@@ -111,7 +150,7 @@ kubectl run -it --rm debug --image=alpine --overrides='{"spec":{"nodeName":"'$NO
 
 Inside the pod, run `hostname` and then exit. The command should succeed, which proves the kubelet serving cert is trusted by the API server.
 
-### 9. Uncordon the node
+### 10. Uncordon the node
 
 ```bash
 kubectl uncordon "$NODE_NAME"

--- a/pkg/ekcoops/csr_test.go
+++ b/pkg/ekcoops/csr_test.go
@@ -1,0 +1,316 @@
+package ekcoops
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// generateCSR creates a PEM-encoded x509 Certificate Signing Request for use
+// in tests. The caller owns the subject and SANs; the generated private key
+// is discarded because the approver only inspects the request.
+func generateCSR(t *testing.T, org []string, commonName string, dnsNames []string, ipAddresses []net.IP, extraEmails []string, extraURIs []string) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	var uris []*url.URL
+	for _, u := range extraURIs {
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		uris = append(uris, parsed)
+	}
+
+	template := x509.CertificateRequest{
+		Subject: pkix.Name{
+			Organization: org,
+			CommonName:   commonName,
+		},
+		DNSNames:       dnsNames,
+		IPAddresses:    ipAddresses,
+		EmailAddresses: extraEmails,
+		URIs:           uris,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+}
+
+func TestReconcileCertificateSigningRequests(t *testing.T) {
+	validNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeHostName, Address: "worker-1"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+			},
+		},
+	}
+
+	apiServerDNSNames := []string{
+		"kubernetes",
+		"kubernetes.default",
+		"kubernetes.default.svc",
+		"kubernetes.default.svc.cluster.local",
+		"apiserver.internal",
+	}
+	apiServerIPs := []net.IP{
+		net.ParseIP("10.96.0.1"),
+		net.ParseIP("10.128.0.7"),
+	}
+
+	validCSR := &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1-serving"},
+		Spec: certificatesv1.CertificateSigningRequestSpec{
+			Username:   "system:node:worker-1",
+			SignerName: "kubernetes.io/kubelet-serving",
+			Usages: []certificatesv1.KeyUsage{
+				certificatesv1.UsageDigitalSignature,
+				certificatesv1.UsageKeyEncipherment,
+				certificatesv1.UsageServerAuth,
+			},
+			Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, nil, nil),
+		},
+	}
+
+	tests := []struct {
+		name         string
+		csr          *certificatesv1.CertificateSigningRequest
+		nodes        []runtime.Object
+		wantApproved bool
+	}{
+		{
+			name:         "valid kubelet-serving CSR from the node itself is approved",
+			csr:          validCSR,
+			nodes:        []runtime.Object{validNode},
+			wantApproved: true,
+		},
+		{
+			name: "ServiceAccount requesting API server names for a node is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "attack-apiserver-names"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:serviceaccount:default:pwn",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", apiServerDNSNames, apiServerIPs, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "bootstrap token requesting kubelet-serving cert is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "attack-bootstrap"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:bootstrap:token",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "CSR with wrong subject organization is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "wrong-organization"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:foo"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "CSR with requester name not matching CommonName is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "mismatched-requester"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-2",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "CSR with SAN not belonging to the node is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "san-not-on-node"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", apiServerDNSNames, apiServerIPs, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "CSR for a non-existent node is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "missing-node"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:ghost",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:ghost", []string{"ghost"}, []net.IP{net.ParseIP("10.0.0.99")}, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{},
+			wantApproved: false,
+		},
+		{
+			name: "CSR with EmailAddresses is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "email-in-csr"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, []string{"attacker@example.com"}, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "CSR with URIs is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "uri-in-csr"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, nil, []string{"spiffe://example.com/worker-1"}),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "CSR with a different signer is not approved",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "wrong-signer"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kube-apiserver-client",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
+			name: "already-approved CSR is left alone",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "already-approved"},
+				Status: certificatesv1.CertificateSigningRequestStatus{
+					Conditions: []certificatesv1.CertificateSigningRequestCondition{
+						{
+							Type:   certificatesv1.CertificateApproved,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: validCSR.Spec.Request,
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resources := append([]runtime.Object{tt.csr}, tt.nodes...)
+			client := fake.NewSimpleClientset(resources...)
+			operator := New(Config{AutoApproveKubeletCertSigningRequests: true}, client, nil, zap.NewNop().Sugar())
+
+			err := operator.reconcileCertificateSigningRequests(context.Background())
+			require.NoError(t, err)
+
+			got, err := client.CertificatesV1().CertificateSigningRequests().Get(context.Background(), tt.csr.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+
+			approved := false
+			for _, cond := range got.Status.Conditions {
+				if cond.Type == certificatesv1.CertificateApproved && cond.Status == corev1.ConditionTrue {
+					approved = true
+				}
+			}
+			require.Equal(t, tt.wantApproved, approved, "CSR %q approval status mismatch", tt.csr.Name)
+		})
+	}
+}

--- a/pkg/ekcoops/csr_test.go
+++ b/pkg/ekcoops/csr_test.go
@@ -103,6 +103,42 @@ func TestReconcileCertificateSigningRequests(t *testing.T) {
 			wantApproved: true,
 		},
 		{
+			name: "valid ECDSA kubelet-serving CSR with only digital signature and server auth is approved",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "worker-1-serving-ecdsa"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageServerAuth,
+					},
+					Request: generateCSR(t, []string{"system:nodes"}, "system:node:worker-1", []string{"worker-1"}, []net.IP{net.ParseIP("10.0.0.1")}, nil, nil),
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: true,
+		},
+		{
+			name: "CSR with an extra usage is rejected",
+			csr: &certificatesv1.CertificateSigningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "extra-usage"},
+				Spec: certificatesv1.CertificateSigningRequestSpec{
+					Username:   "system:node:worker-1",
+					SignerName: "kubernetes.io/kubelet-serving",
+					Usages: []certificatesv1.KeyUsage{
+						certificatesv1.UsageDigitalSignature,
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageServerAuth,
+						certificatesv1.UsageClientAuth,
+					},
+					Request: validCSR.Spec.Request,
+				},
+			},
+			nodes:        []runtime.Object{validNode},
+			wantApproved: false,
+		},
+		{
 			name: "ServiceAccount requesting API server names for a node is rejected",
 			csr: &certificatesv1.CertificateSigningRequest{
 				ObjectMeta: metav1.ObjectMeta{Name: "attack-apiserver-names"},

--- a/pkg/ekcoops/operator.go
+++ b/pkg/ekcoops/operator.go
@@ -4,7 +4,12 @@ package ekcoops
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"net"
+	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -373,6 +378,10 @@ func (o *Operator) reconcileCertificateSigningRequests(ctx context.Context) erro
 			continue
 		}
 		if len(csr.Status.Conditions) == 0 && len(csr.Status.Certificate) == 0 {
+			if !o.isValidKubeletServingCSR(ctx, &csr) {
+				o.log.Debugf("CSR %s failed kubelet-serving validation, skipping approval", csr.Name)
+				continue
+			}
 			csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
 				Type:    certificatesv1.CertificateApproved,
 				Reason:  "ekcoApprove",
@@ -387,6 +396,90 @@ func (o *Operator) reconcileCertificateSigningRequests(ctx context.Context) erro
 		}
 	}
 	return nil
+}
+
+// isValidKubeletServingCSR validates that a kubelet-serving CSR was submitted by
+// the node named in the certificate subject and that every requested SAN is a
+// known address of that node. This prevents any principal that can create a CSR
+// from obtaining a cluster-CA-signed certificate for arbitrary names such as the
+// API server's.
+func (o *Operator) isValidKubeletServingCSR(ctx context.Context, csr *certificatesv1.CertificateSigningRequest) bool {
+	if !isKubeletServingUsages(csr.Spec.Usages) {
+		return false
+	}
+
+	block, _ := pem.Decode(csr.Spec.Request)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return false
+	}
+
+	x509cr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return false
+	}
+
+	if !reflect.DeepEqual(x509cr.Subject.Organization, []string{"system:nodes"}) {
+		return false
+	}
+
+	if !strings.HasPrefix(x509cr.Subject.CommonName, "system:node:") {
+		return false
+	}
+	nodeName := strings.TrimPrefix(x509cr.Subject.CommonName, "system:node:")
+
+	if csr.Spec.Username != x509cr.Subject.CommonName {
+		return false
+	}
+
+	if len(x509cr.EmailAddresses) > 0 || len(x509cr.URIs) > 0 {
+		return false
+	}
+
+	node, err := o.client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return false
+	}
+
+	nodeAddresses := make(map[string]bool)
+	for _, addr := range node.Status.Addresses {
+		nodeAddresses[addr.Address] = true
+	}
+
+	for _, dns := range x509cr.DNSNames {
+		if !nodeAddresses[dns] {
+			return false
+		}
+	}
+
+	for _, ip := range x509cr.IPAddresses {
+		found := false
+		for addr := range nodeAddresses {
+			if ip.Equal(net.ParseIP(addr)) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}
+
+// isKubeletServingUsages reports whether the requested usages match the exact
+// set expected for a kubelet serving certificate.
+func isKubeletServingUsages(usages []certificatesv1.KeyUsage) bool {
+	if len(usages) != 3 {
+		return false
+	}
+	usageSet := make(map[certificatesv1.KeyUsage]bool)
+	for _, u := range usages {
+		usageSet[u] = true
+	}
+	return usageSet[certificatesv1.UsageDigitalSignature] &&
+		usageSet[certificatesv1.UsageKeyEncipherment] &&
+		usageSet[certificatesv1.UsageServerAuth]
 }
 
 func (o *Operator) reconcileMinio(ctx context.Context) error {

--- a/pkg/ekcoops/operator.go
+++ b/pkg/ekcoops/operator.go
@@ -467,19 +467,33 @@ func (o *Operator) isValidKubeletServingCSR(ctx context.Context, csr *certificat
 	return true
 }
 
-// isKubeletServingUsages reports whether the requested usages match the exact
-// set expected for a kubelet serving certificate.
+// isKubeletServingUsages reports whether the requested usages are valid for a
+// kubelet serving certificate. The request must include "server auth" and may
+// include "digital signature" and/or "key encipherment". RSA keys typically
+// request all three, while ECDSA keys only request "digital signature" and
+// "server auth". Any other usage is rejected.
 func isKubeletServingUsages(usages []certificatesv1.KeyUsage) bool {
-	if len(usages) != 3 {
+	if len(usages) == 0 {
 		return false
 	}
 	usageSet := make(map[certificatesv1.KeyUsage]bool)
 	for _, u := range usages {
 		usageSet[u] = true
 	}
-	return usageSet[certificatesv1.UsageDigitalSignature] &&
-		usageSet[certificatesv1.UsageKeyEncipherment] &&
-		usageSet[certificatesv1.UsageServerAuth]
+	if !usageSet[certificatesv1.UsageServerAuth] {
+		return false
+	}
+	for u := range usageSet {
+		switch u {
+		case certificatesv1.UsageDigitalSignature,
+			certificatesv1.UsageKeyEncipherment,
+			certificatesv1.UsageServerAuth:
+			// allowed
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func (o *Operator) reconcileMinio(ctx context.Context) error {


### PR DESCRIPTION
Fixes GHSA-x7j5-fww5-mqmv.

`reconcileCertificateSigningRequests` previously approved any pending `kubernetes.io/kubelet-serving` CSR without inspecting the requester, the certificate request, or the node. This allowed any principal that can create a CSR to obtain a cluster-CA-signed certificate for arbitrary names, including the Kubernetes API server.

The approval logic now validates:
- `Spec.Usages` matches the expected kubelet-serving set.
- The embedded x509 request subject has `O=system:nodes` and `CN=system:node:<nodeName>`.
- The authenticated requester (`Spec.Username`) equals the certificate CommonName.
- The CSR does not include `EmailAddresses` or `URIs`.
- The named Node exists in the cluster.
- Every DNS name and IP address in the CSR appears in `node.Status.Addresses`.

Invalid CSRs are skipped with a debug log; only valid ones are approved.

### Testing
- Added regression tests in `pkg/ekcoops/csr_test.go` covering valid CSRs and the attack cases described in the advisory.
- Added a manual cluster testing guide in `docs/testing-kubelet-csr-rotation.md`.
- `make test` passes: lint, vet, and `go test ./pkg/... ./cmd/...`.
- `make build` succeeds.
